### PR TITLE
Collaboration

### DIFF
--- a/cadcAccessControl-Admin/build.xml
+++ b/cadcAccessControl-Admin/build.xml
@@ -155,8 +155,11 @@
   <property name="easymock"   value="${ext.dev}/easymock.jar" />
   <property name="junit"      value="${ext.dev}/junit.jar" />
   <property name="objenesis"  value="${ext.dev}/objenesis.jar" />
+  <property name="jdom2" value="${ext.dev}/jdom2.jar"/>
+  <property name="json" value="${ext.dev}/json.jar" />
+  <property name="jsonassert" value="${ext.dev}/jsonassert.jar" />
 
-  <property name="testingJars" value="${junit}:${asm}:${cglib}:${easymock}:${objenesis}:{unboundid}:${cadcLog}"/>
+  <property name="testingJars" value="${jsonassert}:${junit}:${asm}:${cglib}:${easymock}:${objenesis}:${jdom2}:${json}:${cadcLog}"/>
 
   <target name="int-test" depends="build,compile-test,setup-test">
     <echo message="Running test suite..."/>

--- a/cadcAccessControl-Admin/src/ca/nrc/cadc/ac/admin/CmdLineParser.java
+++ b/cadcAccessControl-Admin/src/ca/nrc/cadc/ac/admin/CmdLineParser.java
@@ -231,7 +231,7 @@ public class CmdLineParser
                 }
                 else
                 {
-                    throw new UsageException("Missing parameter 'dn'");
+                    this.command = new ApproveUser(userID);
                 }
     	    }
 

--- a/cadcAccessControl-Server/build.xml
+++ b/cadcAccessControl-Server/build.xml
@@ -124,9 +124,10 @@
   <property name="dev.easyMock" value="${ext.dev}/easymock.jar"/>
   <property name="dev.objenesis" value="${ext.dev}/objenesis.jar"/>
   <property name="dev.jsonassert" value="${ext.dev}/jsonassert.jar" />
+  <property name="dev.mail"  value="${ext.dev}/mail.jar" />
   <property name="lib.xerces" value="${ext.lib}/xerces.jar"/>
   <property name="lib.commons-logging" value="${ext.lib}/commons-logging.jar"/>
-  <property name="testingJars" value="${lib.commons-logging}:${dev.junit}:${dev.jsonassert}:${dev.asm}:${dev.cglib}:${dev.easyMock}:${dev.objenesis}:${lib.xerces}"/>
+  <property name="testingJars" value="${lib.commons-logging}:${dev.junit}:${dev.jsonassert}:${dev.asm}:${dev.cglib}:${dev.easyMock}:${dev.objenesis}:${lib.xerces}:${dev.mail}"/>
 
   <target name="single-test" depends="compile,compile-test">
     <echo message="Running test suite..." />

--- a/cadcAccessControl/build.xml
+++ b/cadcAccessControl/build.xml
@@ -112,8 +112,8 @@
     <property name="junit"      value="${ext.dev}/junit.jar" />
     <property name="objenesis"  value="${ext.dev}/objenesis.jar" />
     <property name="jsonassert" value="${ext.dev}/jsonassert.jar" />
-    
-    <property name="testingJars" value="${build}/class:${jsonassert}:${jars}:${xerces}:${asm}:${cglib}:${easymock}:${junit}:${objenesis}" />
+    <property name="mail"  value="${ext.dev}/mail.jar" />
+    <property name="testingJars" value="${build}/class:${xerces}:${jsonassert}:${jars}:${asm}:${cglib}:${easymock}:${junit}:${objenesis}:${mail}" />
 
     <target name="single-test" depends="compile,compile-test">
         <echo message="Running test suite..." />


### PR DESCRIPTION
A little fix in build.xml
Changes in ApproveUser.java and CmdLineParser.java to manage the user approval in case the user already has DN in user request and the dn is not provided by command line.
Tests already executed:
- Try to approve a user not present in UserRequests. Answer: User not found in UserRequests
- Try to approve a user not having DN in user request without providing DN by command line. Answer: Provide a --dn parameter.
- Try to approve a user not having DN in user request providing DN by command line. Answer: user approved.