### PR TITLE
added getPoolStatistics so test code can access stat summary

### DIFF
--- a/cadc-access-control-server/build.gradle
+++ b/cadc-access-control-server/build.gradle
@@ -13,7 +13,7 @@ repositories {
 sourceCompatibility = 1.7
 group = 'org.opencadc'
 
-version = '1.1.3'
+version = '1.1.4'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/ldap/LdapConnectionPool.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/ldap/LdapConnectionPool.java
@@ -210,6 +210,13 @@ public class LdapConnectionPool
             logger.debug(poolName + " pool statistics after release:\n" + pool.getConnectionPoolStatistics());
         }
     }
+    
+    public String getPoolStatistics()
+    {
+        if (pool != null)
+            return poolName + " pool statistics: " + pool.getConnectionPoolStatistics();
+        return null;
+    }
 
     public LdapConfig getCurrentConfig()
     {


### PR DESCRIPTION
without resorting to debug logging on the whole package