### PR TITLE
S2325

### DIFF
--- a/cadc-access-control/build.gradle
+++ b/cadc-access-control/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.12'
+version = '1.1.13'
 
 mainClassName = 'ca.nrc.cadc.ac.client.Main'
 

--- a/cadc-access-control/src/main/java/ca/nrc/cadc/ac/json/JsonGroupReader.java
+++ b/cadc-access-control/src/main/java/ca/nrc/cadc/ac/json/JsonGroupReader.java
@@ -108,13 +108,6 @@ public class JsonGroupReader extends GroupReader
         try
         {
             JsonInputter jsonInputter = new JsonInputter();
-            jsonInputter.getListElementMap().put(IDENTITIES, IDENTITY);
-            jsonInputter.getListElementMap().put(PROPERTIES, PROPERTY);
-            jsonInputter.getListElementMap().put(GROUP_MEMBERS, GROUP);
-            jsonInputter.getListElementMap().put(GROUP_ADMINS, GROUP);
-            jsonInputter.getListElementMap().put(USER_MEMBERS, USER);
-            jsonInputter.getListElementMap().put(USER_ADMINS, USER);
-
             Document document = jsonInputter.input(json);
             return getGroup(document.getRootElement());
         }

--- a/cadc-access-control/src/main/java/ca/nrc/cadc/ac/json/JsonUserListReader.java
+++ b/cadc-access-control/src/main/java/ca/nrc/cadc/ac/json/JsonUserListReader.java
@@ -107,9 +107,6 @@ public class JsonUserListReader extends UserListReader
         try
         {
             JsonInputter jsonInputter = new JsonInputter();
-            jsonInputter.getListElementMap().put(IDENTITIES, IDENTITY);
-            jsonInputter.getListElementMap().put(USERS, USER);
-
             Document document = jsonInputter.input(json);
             return getUserList(document.getRootElement());
         }

--- a/cadc-access-control/src/main/java/ca/nrc/cadc/ac/json/JsonUserReader.java
+++ b/cadc-access-control/src/main/java/ca/nrc/cadc/ac/json/JsonUserReader.java
@@ -107,8 +107,6 @@ public class JsonUserReader extends UserReader
         try
         {
             JsonInputter jsonInputter = new JsonInputter();
-            jsonInputter.getListElementMap().put(IDENTITIES, IDENTITY);
-
             Document document = jsonInputter.input(json);
             return getUser(document.getRootElement());
         }

--- a/cadc-access-control/src/main/java/ca/nrc/cadc/ac/json/JsonUserRequestReader.java
+++ b/cadc-access-control/src/main/java/ca/nrc/cadc/ac/json/JsonUserRequestReader.java
@@ -107,8 +107,6 @@ public class JsonUserRequestReader extends UserRequestReader
         try
         {
             JsonInputter jsonInputter = new JsonInputter();
-            jsonInputter.getListElementMap().put(IDENTITIES, IDENTITY);
-
             Document document = jsonInputter.input(json);
             return getUserRequest(document.getRootElement());
         }

--- a/cadc-access-control/src/main/java/ca/nrc/cadc/ac/xml/AbstractReaderWriter.java
+++ b/cadc-access-control/src/main/java/ca/nrc/cadc/ac/xml/AbstractReaderWriter.java
@@ -196,29 +196,7 @@ public abstract class AbstractReaderWriter
             List<Element> identityElements = identitiesElement.getChildren(IDENTITY);
             for (Element identityElement : identityElements)
             {
-                List<Element> children =  identityElement.getChildren();
-                if (children.isEmpty())
-                {
-                    // xml document
-                    user.getIdentities().add(getPrincipal(identityElement));
-                }
-                else
-                {
-                    for (Element child : children)
-                    {
-                        if (IDENTITY.equals(child.getName()))
-                        {
-                            // json document
-                            user.getIdentities().add(getPrincipal(child));
-                        }
-                        else
-                        {
-                            // xml document
-                            user.getIdentities().add(getPrincipal(identityElement));
-                            break;
-                        }
-                    }
-                }
+                user.getIdentities().add(getPrincipal(identityElement));
             }
         }
 
@@ -548,29 +526,7 @@ public abstract class AbstractReaderWriter
             List<Element> propertyElements = propertiesElement.getChildren(PROPERTY);
             for (Element propertyElement : propertyElements)
             {
-                List<Element> children =  propertyElement.getChildren();
-                if (children.isEmpty())
-                {
-                    // xml document
-                    group.getProperties().add(getGroupProperty(propertyElement));
-                }
-                else
-                {
-                    for (Element child : children)
-                    {
-                        if (PROPERTY.equals(child.getName()))
-                        {
-                            // json document
-                            group.getProperties().add(getGroupProperty(child));
-                        }
-                        else
-                        {
-                            // xml document
-                            group.getProperties().add(getGroupProperty(propertyElement));
-                            break;
-                        }
-                    }
-                }
+                group.getProperties().add(getGroupProperty(propertyElement));
             }
         }
 
@@ -581,29 +537,7 @@ public abstract class AbstractReaderWriter
             List<Element> groupElements = groupMembersElement.getChildren(GROUP);
             for (Element groupMember : groupElements)
             {
-                List<Element> children =  groupMember.getChildren();
-                if (children.isEmpty())
-                {
-                    // xml document
-                    group.getGroupMembers().add(getGroup(groupMember));
-                }
-                else
-                {
-                    for (Element child : children)
-                    {
-                        if (GROUP.equals(child.getName()))
-                        {
-                            // json document
-                            group.getGroupMembers().add(getGroup(child));
-                        }
-                        else
-                        {
-                            // xml document
-                            group.getGroupMembers().add(getGroup(groupMember));
-                            break;
-                        }
-                    }
-                }
+                group.getGroupMembers().add(getGroup(groupMember));
             }
         }
 
@@ -614,29 +548,7 @@ public abstract class AbstractReaderWriter
             List<Element> userElements = userMembersElement.getChildren(USER);
             for (Element userMember : userElements)
             {
-                List<Element> children =  userMember.getChildren();
-                if (children.isEmpty())
-                {
-                    // xml document
-                    group.getUserMembers().add(getUser(userMember));
-                }
-                else
-                {
-                    for (Element child : children)
-                    {
-                        if (USER.equals(child.getName()))
-                        {
-                            // json document
-                            group.getUserMembers().add(getUser(child));
-                        }
-                        else
-                        {
-                            // xml document
-                            group.getUserMembers().add(getUser(userMember));
-                            break;
-                        }
-                    }
-                }
+                group.getUserMembers().add(getUser(userMember));
             }
         }
 
@@ -647,29 +559,7 @@ public abstract class AbstractReaderWriter
             List<Element> groupElements = groupAdminsElement.getChildren(GROUP);
             for (Element groupMember : groupElements)
             {
-                List<Element> children =  groupMember.getChildren();
-                if (children.isEmpty())
-                {
-                    // xml document
-                    group.getGroupAdmins().add(getGroup(groupMember));
-                }
-                else
-                {
-                    for (Element child : children)
-                    {
-                        if (GROUP.equals(child.getName()))
-                        {
-                            // json document
-                            group.getGroupAdmins().add(getGroup(child));
-                        }
-                        else
-                        {
-                            // xml document
-                            group.getGroupAdmins().add(getGroup(groupMember));
-                            break;
-                        }
-                    }
-                }
+                group.getGroupAdmins().add(getGroup(groupMember));
             }
         }
 
@@ -680,29 +570,7 @@ public abstract class AbstractReaderWriter
             List<Element> userElements = userAdminsElement.getChildren(USER);
             for (Element userMember : userElements)
             {
-                List<Element> children =  userMember.getChildren();
-                if (children.isEmpty())
-                {
-                    // xml document
-                    group.getUserAdmins().add(getUser(userMember));
-                }
-                else
-                {
-                    for (Element child : children)
-                    {
-                        if (USER.equals(child.getName()))
-                        {
-                            // json document
-                            group.getUserAdmins().add(getUser(child));
-                        }
-                        else
-                        {
-                            // xml document
-                            group.getUserAdmins().add(getUser(userMember));
-                            break;
-                        }
-                    }
-                }
+                group.getUserAdmins().add(getUser(userMember));
             }
         }
 

--- a/cadc-access-control/src/main/java/ca/nrc/cadc/ac/xml/UserListReader.java
+++ b/cadc-access-control/src/main/java/ca/nrc/cadc/ac/xml/UserListReader.java
@@ -192,26 +192,7 @@ public class UserListReader extends AbstractReaderWriter
         List<Element> userElements = element.getChildren(USER);
         for (Element userElement : userElements)
         {
-            List<Element> children = userElement.getChildren();
-            if (children.isEmpty())
-            {
-                users.add(getUser(userElement));
-            }
-            else
-            {
-                for (Element child : userElement.getChildren())
-                {
-                    if (USER.equals(child.getName()))
-                    {
-                        users.add(getUser(child));
-                    }
-                    else
-                    {
-                        users.add(getUser(userElement));
-                        break;
-                    }
-                }
-            }
+            users.add(getUser(userElement));
         }
 
         return users;

--- a/cadc-access-control/src/main/java/ca/nrc/cadc/ac/xml/UserRequestReader.java
+++ b/cadc-access-control/src/main/java/ca/nrc/cadc/ac/xml/UserRequestReader.java
@@ -81,7 +81,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
-import java.security.Principal;
 
 /**
  * Class to read a XML representation of a UserRequest to a UserRequest object.
@@ -159,7 +158,7 @@ public class UserRequestReader extends AbstractReaderWriter
             String error = "XML failed validation: " + jde.getMessage();
             throw new ReaderException(error, jde);
         }
-
+        
         // Root element and namespace of the Document
         Element root = document.getRootElement();
 


### PR DESCRIPTION
Reverted previous changes since the unit test failures were the results of a bug in JsonInputter as pointed out by Pat.

Removed usage of JsonInputter.getListElementMap() since this was no longer available. This was a way to recover the name of an item in an array of items. JsonInputter can now recover the item name without the need to use the listElementMap.