### PR TITLE
s2681 - updated the GMSClient to catch a ResourceNotFoundException

### DIFF
--- a/cadc-access-control/build.gradle
+++ b/cadc-access-control/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.19'
+version = '1.1.20'
 
 mainClassName = 'ca.nrc.cadc.ac.client.Main'
 
@@ -24,7 +24,7 @@ dependencies {
     compile 'org.jdom:jdom2:2.+'
     compile 'org.json:json:20160212'
 
-    compile 'org.opencadc:cadc-util:[1.2.21,)'
+    compile 'org.opencadc:cadc-util:[1.3.4,)'
     compile 'org.opencadc:cadc-cdp:[1.0,)'
     compile 'org.opencadc:cadc-registry:1.+'
     compile 'org.opencadc:cadc-gms:[1.0,)'

--- a/cadc-access-control/src/main/java/ca/nrc/cadc/ac/client/GMSClient.java
+++ b/cadc-access-control/src/main/java/ca/nrc/cadc/ac/client/GMSClient.java
@@ -90,6 +90,7 @@ import ca.nrc.cadc.net.HttpTransfer;
 import ca.nrc.cadc.net.HttpUpload;
 import ca.nrc.cadc.net.InputStreamWrapper;
 import ca.nrc.cadc.net.NetUtil;
+import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.net.event.TransferEvent;
 import ca.nrc.cadc.net.event.TransferListener;
 import ca.nrc.cadc.reg.Standards;
@@ -97,7 +98,6 @@ import ca.nrc.cadc.reg.client.RegistryClient;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -500,7 +500,7 @@ public class GMSClient implements TransferListener, GroupClient
             {
                 throw new IllegalArgumentException(error.getMessage());
             }
-            if (error instanceof FileNotFoundException)
+            if (error instanceof ResourceNotFoundException)
             {
                 throw new GroupNotFoundException(error.getMessage());
             }
@@ -660,7 +660,7 @@ public class GMSClient implements TransferListener, GroupClient
             {
                 throw new IllegalArgumentException(error.getMessage());
             }
-            if (error instanceof FileNotFoundException)
+            if (error instanceof ResourceNotFoundException)
             {
                 throw new GroupNotFoundException(error.getMessage());
             }
@@ -709,7 +709,7 @@ public class GMSClient implements TransferListener, GroupClient
             {
                 throw new IllegalArgumentException(error.getMessage());
             }
-            if (error instanceof FileNotFoundException)
+            if (error instanceof ResourceNotFoundException)
             {
                 String errMessage = error.getMessage();
                 if (errMessage != null && errMessage.toLowerCase().contains("user"))


### PR DESCRIPTION
The HTTP classes in the net package in cadc-util were updated to throw a ResourceNotFoundException instead of a FileNotFoundException. This updates the GMSClient to catch the ResourceNotFoundException.