### PR TITLE
CADC-9905, 9909: OIDC login through CADC login page

### DIFF
--- a/cadc-access-control-server/build.gradle
+++ b/cadc-access-control-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.3.10'
+version = '1.3.11'
 
 description = 'OpenCADC User+Group server library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
@@ -71,12 +71,14 @@ import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.auth.HttpPrincipal;
 import ca.nrc.cadc.auth.NotAuthenticatedException;
 import ca.nrc.cadc.net.NetUtil;
+import ca.nrc.cadc.reg.client.RegistryClient;
 import ca.nrc.cadc.rest.RestAction;
 
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Set;
@@ -209,9 +211,18 @@ public abstract class AuthorizeAction extends RestAction {
         Subject s = AuthenticationUtil.getCurrentSubject();
         AuthMethod authMethod = AuthenticationUtil.getAuthMethodFromCredentials(s);
         if (authMethod.equals(AuthMethod.ANON)) {
-            
+            // Get the service URL for ac
+            RegistryClient regClient = new RegistryClient();
+            URL regCapabilitiesURL = regClient.getAccessURL(new URI("ivo://cadc.nrc.ca/reg"));
+
+            String regCapURLStr = regCapabilitiesURL.toString();
+            String oidcLoginHostURL = regCapURLStr.replace("/reg/capabilities","");
+
             // send redirect to username/password form
-            StringBuilder redirect = new StringBuilder("oidc-login.html#redirect_uri=");
+            // In future, this reference to /en/login.html can be replaced by
+            // a provide an arbitrary login screen.
+            StringBuilder redirect = new StringBuilder(oidcLoginHostURL);
+            redirect.append("/en/login.html#redirect_uri=");
             redirect.append(redirectURI);
             if (loginHint != null) {
                 redirect.append("&username=");

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
@@ -219,7 +219,7 @@ public abstract class AuthorizeAction extends RestAction {
 
             // send redirect to username/password form
             // In future, this reference to /en/login.html can be replaced by
-            // an arbitrary login screen.
+            // a mechanism to provide an arbitrary login screen.
             StringBuilder redirect = new StringBuilder(oidcLoginHostURL);
             redirect.append("/en/login.html#redirect_uri=");
             redirect.append(redirectURI);

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
@@ -215,12 +215,11 @@ public abstract class AuthorizeAction extends RestAction {
             RegistryClient regClient = new RegistryClient();
             URL regCapabilitiesURL = regClient.getAccessURL(new URI("ivo://cadc.nrc.ca/reg"));
 
-            String regCapURLStr = regCapabilitiesURL.toString();
-            String oidcLoginHostURL = regCapURLStr.replace("/reg/capabilities","");
+            String oidcLoginHostURL = regCapabilitiesURL.getHost();
 
             // send redirect to username/password form
             // In future, this reference to /en/login.html can be replaced by
-            // a provide an arbitrary login screen.
+            // an arbitrary login screen.
             StringBuilder redirect = new StringBuilder(oidcLoginHostURL);
             redirect.append("/en/login.html#redirect_uri=");
             redirect.append(redirectURI);

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/LoginAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/LoginAction.java
@@ -137,7 +137,7 @@ public class LoginAction extends RestAction {
         if (rp == null) {
             throw new AccessControlException("login failed, unauthorized client " + clientID);
         }
-        
+
         Subject subject = new Subject();
         subject.getPrincipals().add(new HttpPrincipal(username));
         subject.getPublicCredentials().add(AuthMethod.PASSWORD);
@@ -150,7 +150,7 @@ public class LoginAction extends RestAction {
                     String msg = "login failed, not a member of " + accessGroup;
                     throw new AccessControlException(msg);
                 }
-                
+
                 return null;
             }
         });
@@ -165,9 +165,11 @@ public class LoginAction extends RestAction {
             redirect.append("&state=");
             redirect.append(state);
         }
-        log.debug("redirecting to: " + redirect);
-        syncOutput.setCode(302);
-        syncOutput.setHeader("Location", redirect);
+        log.debug("returning redirect URL: " + redirect);
+
+        syncOutput.setCode(200);
+        syncOutput.setHeader("Content-Type", "text/plain");
+        syncOutput.getOutputStream().write(redirect.toString().getBytes());
     }
     
     @Override


### PR DESCRIPTION
1) change LoginAction.java to return a 200 + the redirect url as returning 302 from this service causes web browsers to take control of the redirect after a POST generating a CORS error and blocking the redirect. 
2) change AuthorizeAction.java to return a reference to <cadc host>/en/login.html instead of oidc-login.html.