### PR TITLE
CADC-9909: https:// missing from front of URL returned led to relative URL for redirect.

### DIFF
--- a/cadc-access-control-server/build.gradle
+++ b/cadc-access-control-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.3.11'
+version = '1.3.12'
 
 description = 'OpenCADC User+Group server library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
@@ -215,13 +215,14 @@ public abstract class AuthorizeAction extends RestAction {
             RegistryClient regClient = new RegistryClient();
             URL regCapabilitiesURL = regClient.getAccessURL(new URI("ivo://cadc.nrc.ca/reg"));
 
-            String oidcLoginHostURL = regCapabilitiesURL.getHost();
+            // set up redirect with parameters needed for OIDC authorization
+            StringBuilder redirect = new StringBuilder(regCapabilitiesURL.getProtocol());
+            redirect.append("://");
+            redirect.append(regCapabilitiesURL.getHost());
 
-            // send redirect to username/password form
-            // In future, this reference to /en/login.html can be replaced by
-            // a mechanism to provide an arbitrary login screen.
-            StringBuilder redirect = new StringBuilder("https://");
-            redirect.append(oidcLoginHostURL);
+            // username/password form
+            // NOTE: In future, this reference to /en/login.html can be replaced by
+            // a mechanism to provide an arbitrary login screen. - HJ July 30, 2021
             redirect.append("/en/login.html#redirect_uri=");
             redirect.append(redirectURI);
             if (loginHint != null) {
@@ -236,6 +237,8 @@ public abstract class AuthorizeAction extends RestAction {
             redirect.append("&client=").append(NetUtil.encode(rp.getClientDescription()));
             String claimDesc = OIDCUtil.getClaimDescriptionString(rp.getClaims());
             redirect.append("&claims=").append(NetUtil.encode(claimDesc));
+
+            log.debug("redirecting to " + redirect.toString());
             syncOutput.setCode(302);
             syncOutput.setHeader("Location", redirect);
             

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/AuthorizeAction.java
@@ -220,7 +220,8 @@ public abstract class AuthorizeAction extends RestAction {
             // send redirect to username/password form
             // In future, this reference to /en/login.html can be replaced by
             // a mechanism to provide an arbitrary login screen.
-            StringBuilder redirect = new StringBuilder(oidcLoginHostURL);
+            StringBuilder redirect = new StringBuilder("https://");
+            redirect.append(oidcLoginHostURL);
             redirect.append("/en/login.html#redirect_uri=");
             redirect.append(redirectURI);
             if (loginHint != null) {


### PR DESCRIPTION
Found when deployed to rc. (Not sure how this got missed in dev.)