### PR TITLE
changed TokenTool.validate to accept multiple Grant classes

### DIFF
--- a/cadc-permissions/build.gradle
+++ b/cadc-permissions/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '0.3.1'
+version = '0.3.2'
 description = 'OpenCADC Permissions API library'
 def git_url = 'https://github.com/opencadc/ac'
 

--- a/cadc-permissions/src/main/java/org/opencadc/permissions/TokenTool.java
+++ b/cadc-permissions/src/main/java/org/opencadc/permissions/TokenTool.java
@@ -184,12 +184,13 @@ public class TokenTool {
      * 
      * @param token The token to validate.
      * @param expectedURI The expected artifact URI.
-     * @param expectedGrantClass The expected grant applied to the artifact.
+     * @param expectedGrantClass one or more expected grant types (single match is valid)
      * @return The user contained in the token.
      * @throws AccessControlException If any of the expectations are not met or if the token is invalid.
      * @throws IOException If a processing error occurs.
      */
-    public String validateToken(String token, URI expectedURI, Class<? extends Grant> expectedGrantClass) throws AccessControlException, IOException {
+    public String validateToken(String token, URI expectedURI, Class<? extends Grant>... expectedGrantClass) 
+            throws AccessControlException, IOException {
 
         log.debug("validating token: " + token);
         String[] parts = token.split(TOKEN_DELIM);
@@ -245,8 +246,11 @@ public class TokenTool {
             log.debug("wrong target uri");
             throw new AccessControlException("Invalid auth token");
         }
-        if (!expectedGrantClass.getSimpleName().equals(grant)) {
-            log.debug("wrong http method");
+        boolean grantMatch = false;
+        for (Class<? extends Grant> c : expectedGrantClass) {
+            grantMatch = grantMatch || c.getSimpleName().equals(grant);
+        }
+        if (!grantMatch) {
             throw new AccessControlException("Invalid auth token");
         }
         

--- a/cadc-permissions/src/test/java/org/opencadc/permissions/TokenToolTest.java
+++ b/cadc-permissions/src/test/java/org/opencadc/permissions/TokenToolTest.java
@@ -81,7 +81,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.opencadc.permissions.xml.GrantReader;
 
 public class TokenToolTest {
 
@@ -167,6 +166,22 @@ public class TokenToolTest {
         String token = gen.generateToken(URI.create(uri), grant, null);
         String actUser = ver.validateToken(token, URI.create(uri), grant);
         Assert.assertEquals("user", null, actUser);
+    }
+    
+    @Test
+    public void testVarArgsValidate() throws Exception {
+        String uri = "cadc:TEST/file.fits";
+        Class<? extends Grant> grant = ReadGrant.class;
+        Class<? extends Grant> otherGrant = WriteGrant.class;
+        TokenTool gen = new TokenTool(pubKeyFile, privateKeyFile);
+        TokenTool ver = new TokenTool(pubKeyFile);
+        String token = gen.generateToken(URI.create(uri), grant, null);
+        
+        String actUser1 = ver.validateToken(token, URI.create(uri), grant, otherGrant);
+        Assert.assertEquals("user", null, actUser1);
+        
+        String actUser2 = ver.validateToken(token, URI.create(uri), otherGrant, grant);
+        Assert.assertEquals("user", null, actUser2);
     }
 
     @Test


### PR DESCRIPTION
reason: allows a service to allow a read when a pre-auth token has a WriteGrant; needed in minoc to allow a head (read) after a put (with write grant pre-auth) both within and after a transaction.

I thought about more explicitly changing WriteGrant to ReadWriteGrant but that would be more invasise right now.