### PR TITLE
Cadc 10630 Updated LoginServlet to prevent incorrect username in tokens

### DIFF
--- a/cadc-access-control-server/build.gradle
+++ b/cadc-access-control-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.3.24'
+version = '1.3.25'
 
 description = 'OpenCADC User+Group server library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/web/LoginServlet.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/web/LoginServlet.java
@@ -92,7 +92,6 @@ import java.security.AccessControlException;
 import java.security.Principal;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Iterator;
 import java.util.Set;
 import javax.security.auth.Subject;
 import javax.servlet.ServletConfig;
@@ -199,23 +198,6 @@ public class LoginServlet extends HttpServlet
                     ai.augmentSubject(userSubject);
                 }
                 Set<Principal> userPrincipals = userSubject.getPrincipals();
-
-                // Remove principal p added above if userID in request differs in case
-                boolean removePrincipal = false;
-                Principal toBeRemoved = null;
-                for (Iterator<Principal> iterator = userPrincipals.iterator(); iterator.hasNext();) {
-                    Principal princ = iterator.next();
-                    if (princ.getName().equalsIgnoreCase(userID)) {
-                        if (princ.getName().equals(userID)) {
-                          toBeRemoved = princ;
-                        } else {
-                            removePrincipal = true;
-                        }
-                    }
-                }
-                if (removePrincipal && toBeRemoved != null) {
-                    userPrincipals.remove(toBeRemoved);
-                }
 
                 if (scope != null)
                 {

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/web/LoginServlet.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/web/LoginServlet.java
@@ -92,6 +92,7 @@ import java.security.AccessControlException;
 import java.security.Principal;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Iterator;
 import java.util.Set;
 import javax.security.auth.Subject;
 import javax.servlet.ServletConfig;
@@ -198,6 +199,23 @@ public class LoginServlet extends HttpServlet
                     ai.augmentSubject(userSubject);
                 }
                 Set<Principal> userPrincipals = userSubject.getPrincipals();
+
+                // Remove principal p added above if userID in request differs in case
+                boolean removePrincipal = false;
+                Principal toBeRemoved = null;
+                for (Iterator<Principal> iterator = userPrincipals.iterator(); iterator.hasNext();) {
+                    Principal princ = iterator.next();
+                    if (princ.getName().equalsIgnoreCase(userID)) {
+                        if (princ.getName().equals(userID)) {
+                          toBeRemoved = princ;
+                        } else {
+                            removePrincipal = true;
+                        }
+                    }
+                }
+                if (removePrincipal && toBeRemoved != null) {
+                    userPrincipals.remove(toBeRemoved);
+                }
 
                 if (scope != null)
                 {

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
@@ -152,13 +152,7 @@ public class AuthenticatorImpl implements Authenticator
 
             // CADC-10630 Remove potentially incorrect userID
             // in HttpPrincipal in subject.
-            Set<Principal> toBeRemoved = new HashSet<Principal>();
-            subject.getPrincipals().forEach(p -> {
-                if (p instanceof HttpPrincipal) {
-                    toBeRemoved.add(p);
-                }
-            });
-            subject.getPrincipals().removeAll(toBeRemoved);
+            subject.getPrincipals().removeAll(subject.getPrincipals(HttpPrincipal.class));
 
             User user = userPersistence.getAugmentedUser(ldapPrincipal, true);
             if (user.getIdentities() != null)

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
@@ -80,8 +80,6 @@ import ca.nrc.cadc.profiler.Profiler;
 
 import java.security.AccessControlException;
 import java.security.Principal;
-import java.util.Iterator;
-import java.util.Set;
 
 import javax.security.auth.Subject;
 import javax.security.auth.x500.X500Principal;
@@ -151,18 +149,7 @@ public class AuthenticatorImpl implements Authenticator
             Principal ldapPrincipal = getLdapPrincipal(subject);
 
             // Remove the HttpPrincipal in subject, if any
-            Principal toBeRemoved = null;
-            Set<Principal> principals = subject.getPrincipals();
-            for (Iterator<Principal> iterator = principals.iterator(); iterator.hasNext();) {
-                Principal princ = iterator.next();
-                if (princ instanceof HttpPrincipal) {
-                    toBeRemoved = princ;
-                    break;
-                }
-            }
-            if (toBeRemoved != null) {
-                subject.getPrincipals().remove(toBeRemoved);
-            }
+            subject.getPrincipals(HttpPrincipal.class).clear();
 
             User user = userPersistence.getAugmentedUser(ldapPrincipal, true);
             if (user.getIdentities() != null)

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
@@ -80,6 +80,8 @@ import ca.nrc.cadc.profiler.Profiler;
 
 import java.security.AccessControlException;
 import java.security.Principal;
+import java.util.Iterator;
+import java.util.Set;
 
 import javax.security.auth.Subject;
 import javax.security.auth.x500.X500Principal;
@@ -147,6 +149,21 @@ public class AuthenticatorImpl implements Authenticator
             PluginFactory pluginFactory = new PluginFactory();
             UserPersistence userPersistence = pluginFactory.createUserPersistence();
             Principal ldapPrincipal = getLdapPrincipal(subject);
+
+            // Remove the HttpPrincipal in subject, if any
+            Principal toBeRemoved = null;
+            Set<Principal> principals = subject.getPrincipals();
+            for (Iterator<Principal> iterator = principals.iterator(); iterator.hasNext();) {
+                Principal princ = iterator.next();
+                if (princ instanceof HttpPrincipal) {
+                    toBeRemoved = princ;
+                    break;
+                }
+            }
+            if (toBeRemoved != null) {
+                subject.getPrincipals().remove(toBeRemoved);
+            }
+
             User user = userPersistence.getAugmentedUser(ldapPrincipal, true);
             if (user.getIdentities() != null)
             {

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
@@ -80,7 +80,6 @@ import ca.nrc.cadc.profiler.Profiler;
 
 import java.security.AccessControlException;
 import java.security.Principal;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
@@ -80,6 +80,9 @@ import ca.nrc.cadc.profiler.Profiler;
 
 import java.security.AccessControlException;
 import java.security.Principal;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.security.auth.Subject;
 import javax.security.auth.x500.X500Principal;
@@ -149,7 +152,15 @@ public class AuthenticatorImpl implements Authenticator
             Principal ldapPrincipal = getLdapPrincipal(subject);
 
             // Remove the HttpPrincipal in subject, if any
-            subject.getPrincipals(HttpPrincipal.class).clear();
+            Set<Principal> toBeRemoved = new HashSet<Principal>();
+            subject.getPrincipals().forEach(p -> {
+                if (p instanceof HttpPrincipal) {
+                    toBeRemoved.add(p);
+                }
+            });
+            toBeRemoved.forEach(p -> {
+                subject.getPrincipals().remove(p);
+            });
 
             User user = userPersistence.getAugmentedUser(ldapPrincipal, true);
             if (user.getIdentities() != null)

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/auth/AuthenticatorImpl.java
@@ -150,16 +150,15 @@ public class AuthenticatorImpl implements Authenticator
             UserPersistence userPersistence = pluginFactory.createUserPersistence();
             Principal ldapPrincipal = getLdapPrincipal(subject);
 
-            // Remove the HttpPrincipal in subject, if any
+            // CADC-10630 Remove potentially incorrect userID
+            // in HttpPrincipal in subject.
             Set<Principal> toBeRemoved = new HashSet<Principal>();
             subject.getPrincipals().forEach(p -> {
                 if (p instanceof HttpPrincipal) {
                     toBeRemoved.add(p);
                 }
             });
-            toBeRemoved.forEach(p -> {
-                subject.getPrincipals().remove(p);
-            });
+            subject.getPrincipals().removeAll(toBeRemoved);
 
             User user = userPersistence.getAugmentedUser(ldapPrincipal, true);
             if (user.getIdentities() != null)


### PR DESCRIPTION
Added logic in LoginServlet to remove the principal created from a userID with different cases than the one in ldap.
