### PR TITLE
CADC-10684: add kid header to JWT so OIDC validator can run

### DIFF
--- a/cadc-access-control-server/build.gradle
+++ b/cadc-access-control-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.3.27'
+version = '1.3.28'
 
 description = 'OpenCADC User+Group server library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/OIDCUtil.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/OIDCUtil.java
@@ -417,10 +417,4 @@ public class OIDCUtil {
         return Base64.getUrlEncoder().encodeToString(KID_CLAIM_VALUE.getBytes());
     }
 
-    public static boolean isRightKIDKey(String encodedKID) {
-        byte[] urlDecodedKIDbytes = Base64.getUrlDecoder().decode(encodedKID.getBytes());
-        String urlDecodedKID = new String(urlDecodedKIDbytes);
-        return KID_CLAIM_VALUE.equals(urlDecodedKID);
-    }
-    
 }

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/OIDCUtil.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/OIDCUtil.java
@@ -146,7 +146,7 @@ public class OIDCUtil {
 
     private static final String PUBLIC_KEY_NAME = "oidc-rsa256-pub.key";
     private static final String PRIVATE_KEY_NAME = "oidc-rsa256-priv.key";
-    private static final String KID_CLAIM_VALUE = "oidc-rsa256-kid-val-1.0";
+    public static final String KID_CLAIM_VALUE = "cadc-key-1.0";
 
     private static Set<PublicKey> publicKeys = null;
     private static Key privateKey = null;
@@ -375,7 +375,7 @@ public class OIDCUtil {
         Set<PublicKey> pubKeys = OIDCUtil.getPublicKeys();
         RSAPublicKey key = ((RSAPublicKey) pubKeys.iterator().next());
         // This value is used to retrieve the corresponding RSA key
-        builder.setHeaderParam("kid", getEncodedKID());
+        builder.setHeaderParam("kid", KID_CLAIM_VALUE);
 
         if (rp.isSignDocuments()) {
             return builder.signWith(OIDCUtil.getPrivateKey(), SignatureAlgorithm.RS256).compact();
@@ -411,10 +411,6 @@ public class OIDCUtil {
             sb.append(c.getDescription());
         }
         return sb.toString();
-    }
-
-    public static String getEncodedKID() {
-        return Base64.getUrlEncoder().encodeToString(KID_CLAIM_VALUE.getBytes());
     }
 
 }

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/PublicKeyAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/PublicKeyAction.java
@@ -91,18 +91,16 @@ import org.apache.log4j.Logger;
 public class PublicKeyAction extends RestAction {
     
     private static final Logger log = Logger.getLogger(PublicKeyAction.class);
-    private static final String KID = UUID.randomUUID().toString();
 
     @Override
     public void doAction() throws Exception {
         log.debug("returning public key as jwks");
-        
         Set<PublicKey> pubKeys = OIDCUtil.getPublicKeys();
         RSAPublicKey key = ((RSAPublicKey) pubKeys.iterator().next());
         
         JWK jwk = new RSAKey.Builder(key)
             .keyUse(KeyUse.SIGNATURE)
-            .keyID(KID)
+            .keyID(OIDCUtil.getEncodedKID())
             .build();
 
         String jwkJSON = jwk.toPublicJWK().toJSONString();

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/PublicKeyAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/PublicKeyAction.java
@@ -100,7 +100,7 @@ public class PublicKeyAction extends RestAction {
         
         JWK jwk = new RSAKey.Builder(key)
             .keyUse(KeyUse.SIGNATURE)
-            .keyID(OIDCUtil.getEncodedKID())
+            .keyID(OIDCUtil.KID_CLAIM_VALUE)
             .build();
 
         String jwkJSON = jwk.toPublicJWK().toJSONString();

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/RelyParty.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/RelyParty.java
@@ -85,7 +85,6 @@ public class RelyParty {
     
     private String clientID;
     private String clientSecret;
-    private String kidVersion;
     private GroupURI accessGroup = null;   // optional
     private String clientDescription;
     private List<Claim> claims = new ArrayList<Claim>();
@@ -127,14 +126,6 @@ public class RelyParty {
     
     public boolean isSignDocuments() {
         return signDocuments;
-    }
-
-    public String getKidVersion() {
-        return kidVersion;
-    }
-
-    public void setKidVersion(String kidVersion) {
-        this.kidVersion = kidVersion;
     }
 
     @Override

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/RelyParty.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/RelyParty.java
@@ -85,6 +85,7 @@ public class RelyParty {
     
     private String clientID;
     private String clientSecret;
+    private String kidVersion;
     private GroupURI accessGroup = null;   // optional
     private String clientDescription;
     private List<Claim> claims = new ArrayList<Claim>();
@@ -126,6 +127,14 @@ public class RelyParty {
     
     public boolean isSignDocuments() {
         return signDocuments;
+    }
+
+    public String getKidVersion() {
+        return kidVersion;
+    }
+
+    public void setKidVersion(String kidVersion) {
+        this.kidVersion = kidVersion;
     }
 
     @Override


### PR DESCRIPTION
Even though this is an optional header, the website we're using to test the quality of our JWTs seems to require it. kid (Key ID) is now set up to be a well known string, but encoded so it's not immediately readable.  (Code in OIDCUtil)

Same value is generated in the JWKS endpoint (code in PublicKeyAction.)