### PR TITLE
Added configured Domains to the Token.

### DIFF
--- a/cadc-access-control-server/build.gradle
+++ b/cadc-access-control-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.3.30'
+version = '1.3.31'
 
 description = 'OpenCADC User+Group server library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/OIDCUtil.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/OIDCUtil.java
@@ -281,10 +281,15 @@ public class OIDCUtil {
     }
     
     public static String getToken(String username, URI scope, int expiryMinutes) throws InvalidKeyException, IOException {
+        return OIDCUtil.getToken(username, scope, expiryMinutes, null);
+    }
+
+    public static String getToken(String username, URI scope, int expiryMinutes, List<String> domains)
+            throws InvalidKeyException, IOException {
         HttpPrincipal p = new HttpPrincipal(username);
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MINUTE, expiryMinutes);
-        SignedToken token = new SignedToken(p, scope, c.getTime(), null);
+        SignedToken token = new SignedToken(p, scope, c.getTime(), domains);
         return SignedToken.format(token);
     }
     


### PR DESCRIPTION
The token at the `/authorize` endpoint is being used to obtain proprietary data, but is missing Domains being encoded in the value, which are necessary to authenticate.  This adds them from the `ac-domains.properties` file.