### PR TITLE
cadc-gms: update GroupURI to allow / (hierarchical) group names; resolves #139 and #142

### DIFF
--- a/cadc-access-control-server/build.gradle
+++ b/cadc-access-control-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.3.31'
+version = '1.3.32'
 
 description = 'OpenCADC User+Group server library'
 def git_url = 'https://github.com/opencadc/ac'
@@ -28,7 +28,7 @@ dependencies {
     compile 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     compile 'com.nimbusds:nimbus-jose-jwt:[9.22,)'
 
-    compile 'org.opencadc:cadc-gms:[1.0.2,2.0)'
+    compile 'org.opencadc:cadc-gms:[1.0.5,2.0)'
     compile 'org.opencadc:cadc-access-control:[1.1.23,2.0)'
     compile 'org.opencadc:cadc-util:[1.9.2,)'
     compile 'org.opencadc:cadc-log:[1.1.0,)'

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/ldap/LdapConfig.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/ldap/LdapConfig.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2019.                            (c) 2019.
+ *  (c) 2023.                            (c) 2023.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -66,16 +66,15 @@
  *
  ************************************************************************
  */
+
 package ca.nrc.cadc.ac.server.ldap;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.ServiceConfigurationError;
-
-import org.apache.log4j.Logger;
 
 import ca.nrc.cadc.util.MultiValuedProperties;
 import ca.nrc.cadc.util.PropertiesReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import org.apache.log4j.Logger;
 
 /**
  * Reads and stores the LDAP configuration information.
@@ -102,11 +101,9 @@ public class LdapConfig
     public static final String MAX_WAIT = "maxWait";
     public static final String CREATE_IF_NEEDED = "createIfNeeded";
 
-    public static final String LDAP_DBRC_ENTRY = "dbrcHost";
-
     public static final String DEFAULT_LDAP_PORT = "port";
     public static final String LDAP_SERVER_PROXY_USER = "proxyUser";
-    public static final String LDAP_SERVER_PROXY_PASSWORD= "proxyPassword";
+    public static final String LDAP_SERVER_PROXY_PASSWORD = "proxyPassword";
     public static final String LDAP_USERS_DN = "usersDN";
     public static final String LDAP_USER_REQUESTS_DN = "userRequestsDN";
     public static final String LDAP_GROUPS_DN = "groupsDN";
@@ -232,7 +229,6 @@ public class LdapConfig
     private String adminGroupsDN;
     private String proxyUserDN;
     private String proxyPasswd;
-    private String dbrcHost;
     private SystemState systemState;
 
     public String getProxyUserDN()
@@ -267,7 +263,6 @@ public class LdapConfig
         loadPoolConfig(ldapConfig.readWritePool, config, READWRITE_PREFIX);
         loadPoolConfig(ldapConfig.unboundReadOnlyPool, config, UB_READONLY_PREFIX);
 
-        ldapConfig.dbrcHost = getProperty(config, LDAP_DBRC_ENTRY);
         String defaultPort = config.getFirstPropertyValue(DEFAULT_LDAP_PORT);
         if (defaultPort != null) {
             ldapConfig.defaultPort = Integer.parseInt(defaultPort);
@@ -383,9 +378,6 @@ public class LdapConfig
         if ( !(l.proxyUserDN.equals(proxyUserDN)))
             return false;
 
-        if ( !(l.dbrcHost.equals(dbrcHost)))
-            return false;
-
         if ( !(l.readOnlyPool.equals(readOnlyPool)))
             return false;
 
@@ -440,11 +432,6 @@ public class LdapConfig
         return this.adminGroupsDN;
     }
 
-    public String getDbrcHost()
-    {
-        return this.dbrcHost;
-    }
-
     public String getAdminUserDN()
     {
         return this.proxyUserDN;
@@ -473,7 +460,6 @@ public class LdapConfig
         sb.append(" ReadWritePool: [" + readWritePool + "]");
         sb.append(" UnboundReadOnlyPool: [" + unboundReadOnlyPool + "]");
         sb.append(" Default Port: " + defaultPort);
-        sb.append(" dbrcHost: " + dbrcHost);
         sb.append(" proxyUserDN: " + proxyUserDN);
 
         return sb.toString();

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/GetConfigAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/oidc/GetConfigAction.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2020.                            (c) 2020.
+ *  (c) 2023.                            (c) 2023.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -64,23 +64,18 @@
  *
  ************************************************************************
  */
+
 package ca.nrc.cadc.ac.server.oidc;
 
 import ca.nrc.cadc.net.ResourceNotFoundException;
-import ca.nrc.cadc.reg.Standards;
-import ca.nrc.cadc.reg.client.LocalAuthority;
-import ca.nrc.cadc.reg.client.RegistryClient;
 import ca.nrc.cadc.rest.InlineContentHandler;
 import ca.nrc.cadc.rest.RestAction;
-
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import org.apache.log4j.Logger;
 
 /**
@@ -120,11 +115,9 @@ public class GetConfigAction extends RestAction {
     }
     
     String getHostname() throws IOException, ResourceNotFoundException {
-        LocalAuthority localAuthority = new LocalAuthority();
-        URI serviceURI = localAuthority.getServiceURI(Standards.SECURITY_METHOD_OAUTH.toString());
-        RegistryClient regClient = new RegistryClient();
-        URL oauthURL = regClient.getAccessURL(serviceURI);
-        return oauthURL.getHost();
+        String req = syncInput.getRequestURI();
+        URL url = new URL(req);
+        return url.getHost();
     }
 
 }

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/web/groups/CreateGroupAction.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/web/groups/CreateGroupAction.java
@@ -77,6 +77,7 @@ import ca.nrc.cadc.ac.Group;
 import ca.nrc.cadc.ac.User;
 import ca.nrc.cadc.ac.xml.GroupReader;
 import ca.nrc.cadc.ac.xml.GroupWriter;
+import org.opencadc.gms.GroupURI;
 
 public class CreateGroupAction extends AbstractGroupAction
 {
@@ -92,6 +93,14 @@ public class CreateGroupAction extends AbstractGroupAction
     {
         GroupReader groupReader = new GroupReader();
         Group group = groupReader.read(this.inputStream);
+        
+        // restriction: prevent hierarchical group names now that GroupURI allows it
+        GroupURI gid = group.getID();
+        String name = gid.getName();
+        String[] ss = name.split("/");
+        if (ss.length > 1) {
+            throw new IllegalArgumentException("invalid group name (/ not permitted): " + name);
+        }
         Group returnGroup = groupPersistence.addGroup(group);
         syncOut.setHeader("Content-Type", "application/xml");
         GroupWriter groupWriter = new GroupWriter();

--- a/cadc-access-control-server/src/test/config/testConfig.offline.properties
+++ b/cadc-access-control-server/src/test/config/testConfig.offline.properties
@@ -30,7 +30,6 @@ unboundReadOnly.maxWait = 30000
 unboundReadOnly.createIfNeeded = false
 
 # server configuration -- applies to all servers
-dbrcHost = devLdap
 port = 389
 proxyUser = uid=testuser,ou=testorg,dc=test
 proxyPassword = 123456

--- a/cadc-access-control-server/src/test/config/testConfig.read-only.properties
+++ b/cadc-access-control-server/src/test/config/testConfig.read-only.properties
@@ -30,7 +30,6 @@ unboundReadOnly.maxWait = 30000
 unboundReadOnly.createIfNeeded = false
 
 # server configuration -- applies to all servers
-dbrcHost = devLdap
 port = 389
 proxyUser = uid=testuser,ou=testorg,dc=test
 proxyPassword = 123456

--- a/cadc-access-control-server/src/test/config/testConfig1.properties
+++ b/cadc-access-control-server/src/test/config/testConfig1.properties
@@ -33,7 +33,6 @@ unboundReadOnly.maxWait = 30000
 unboundReadOnly.createIfNeeded = false
 
 # server configuration -- applies to all servers
-dbrcHost = devLdap
 proxyUser = uid=testuser,ou=testorg,dc=test
 proxyPassword = 123456
 usersDN = usersDN

--- a/cadc-access-control-server/src/test/config/testConfig2.properties
+++ b/cadc-access-control-server/src/test/config/testConfig2.properties
@@ -33,7 +33,6 @@ unboundReadOnly.maxWait = 30000
 unboundReadOnly.createIfNeeded = false
 
 # server configuration -- applies to all servers
-dbrcHost = devLdap
 port = 389
 proxyUser = uid=testuser,ou=testorg,dc=test
 proxyPassword = 123456

--- a/cadc-access-control-server/src/test/java/ca/nrc/cadc/ac/server/ldap/LdapConfigTest.java
+++ b/cadc-access-control-server/src/test/java/ca/nrc/cadc/ac/server/ldap/LdapConfigTest.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2014.                            (c) 2014.
+ *  (c) 2023.                            (c) 2023.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -99,7 +99,6 @@ public class LdapConfigTest
             System.setProperty("user.home", "src/test/config");
 
             LdapConfig c = LdapConfig.loadLdapConfig("testConfig1.properties");
-            Assert.assertEquals("devLdap", c.getDbrcHost());
             Assert.assertEquals(389, c.getReadOnlyPool().getPort());
             Assert.assertEquals(636, c.getReadWritePool().getPort());
             Assert.assertEquals(636, c.getUnboundReadOnlyPool().getPort());
@@ -145,7 +144,6 @@ public class LdapConfigTest
             System.setProperty("user.home", "src/test/config");
 
             LdapConfig c = LdapConfig.loadLdapConfig("testConfig2.properties");
-            Assert.assertEquals("devLdap", c.getDbrcHost());
             Assert.assertEquals(389, c.getReadOnlyPool().getPort());
             Assert.assertEquals(636, c.getReadWritePool().getPort());
             Assert.assertEquals(389, c.getUnboundReadOnlyPool().getPort());

--- a/cadc-access-control/build.gradle
+++ b/cadc-access-control/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.1.25'
+version = '1.1.26'
 
 description = 'OpenCADC User+Group client library'
 def git_url = 'https://github.com/opencadc/ac'
@@ -27,7 +27,7 @@ dependencies {
 
     compile 'org.opencadc:cadc-util:[1.6,2.0)'
     compile 'org.opencadc:cadc-registry:[1.5,2.0)'
-    compile 'org.opencadc:cadc-gms:[1.0.2,1.1)'
+    compile 'org.opencadc:cadc-gms:[1.0.5,1.1)'
     compile 'org.opencadc:cadc-cdp:[1.0,2.0)'
 
     testCompile 'junit:junit:[4.13,5.0)'

--- a/cadc-gms/README.md
+++ b/cadc-gms/README.md
@@ -17,4 +17,10 @@ non-IVOA standard authentication services. The current implementation is a simpl
 prototype that is known to work with an Indigo IAM OIDC issuer. 
 
 See <a href="https://github.com/opencadc/reg/tree/master/cadc-registry">cadc-registry</a>
-for information about configuring an OpenID issuer.
+for information about configuring an OpenID issuer. In addition, if a service also configures
+a "trusted" GMS service in the cadc-registry config file, for example:
+```
+ivo://ivoa.net/std/GMS#search-1.0 = {my GSM service}
+```
+then the StandardIdentityManager will ensure that valid access tokens are tagged so they will
+be used in calls to that GMS service.

--- a/cadc-gms/build.gradle
+++ b/cadc-gms/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.0.4'
+version = '1.0.5'
 
 description = 'OpenCADC GMS API library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-gms/src/main/java/org/opencadc/gms/GroupClient.java
+++ b/cadc-gms/src/main/java/org/opencadc/gms/GroupClient.java
@@ -79,6 +79,7 @@ import java.util.List;
  * @author majorb
  *
  */
+@Deprecated
 public interface GroupClient {
     
     /**

--- a/cadc-gms/src/main/java/org/opencadc/gms/GroupURI.java
+++ b/cadc-gms/src/main/java/org/opencadc/gms/GroupURI.java
@@ -81,7 +81,7 @@ public class GroupURI implements Comparable<GroupURI> {
     private static final Logger log = Logger.getLogger(GroupURI.class);
     
     private URI uri;
-    private static String GROUP_NAME_ERRORMSG = "Group Name contains illegal characters (only alphanumeric, '-', '.', '_', '~' allowed";
+    private static String GROUP_NAME_ERRORMSG = "Group Name contains illegal characters (only alphanumeric, '/', -', '.', '_', '~' allowed";
 
     /**
      * Attempts to create a URI using the specified uri.
@@ -111,17 +111,7 @@ public class GroupURI implements Comparable<GroupURI> {
         String query = uri.getQuery();
         String name = null;
         if (query == null) {
-            if (fragment != null) {
-                // allow the fragment to define the group name (old style)
-                if (isValidGroupName(fragment)) {
-                    name = fragment;
-                } else {
-                    throw new IllegalArgumentException(GROUP_NAME_ERRORMSG);
-                }
-
-            } else {
-                throw new IllegalArgumentException("Group name is required.");
-            }
+            throw new IllegalArgumentException("Group name is required.");
         } else {
             if (fragment != null) {
                 throw new IllegalArgumentException("Fragment not allowed in group URIs");
@@ -134,8 +124,7 @@ public class GroupURI implements Comparable<GroupURI> {
             }
         }
 
-        this.uri = URI.create(
-                uri.getScheme() + "://" + uri.getAuthority() + uri.getPath() + "?" + name);
+        this.uri = URI.create(uri.getScheme() + "://" + uri.getAuthority() + uri.getPath() + "?" + name);
     }
 
     /**
@@ -247,7 +236,7 @@ public class GroupURI implements Comparable<GroupURI> {
     private boolean isValidGroupName(String groupName) {
         boolean isValid = false;
 
-        if (groupName.matches("^[a-zA-Z0-9_\\-\\.~]+$")) {
+        if (groupName.matches("^[a-zA-Z0-9/_\\-\\.~]+$")) {
             isValid = true;
         }
 

--- a/cadc-gms/src/main/java/org/opencadc/gms/GroupUtil.java
+++ b/cadc-gms/src/main/java/org/opencadc/gms/GroupUtil.java
@@ -80,6 +80,7 @@ import org.apache.log4j.Logger;
  * @author majorb
  *
  */
+@Deprecated
 public class GroupUtil {
     
     /**

--- a/cadc-gms/src/main/java/org/opencadc/gms/IvoaGroupClient.java
+++ b/cadc-gms/src/main/java/org/opencadc/gms/IvoaGroupClient.java
@@ -222,7 +222,7 @@ public class IvoaGroupClient {
             }
             queryURL = new URL(sb.toString());
         }
-        log.warn("queryURL: " + queryURL);
+        log.debug("queryURL: " + queryURL);
         
         Set<GroupURI> ret = new TreeSet<>();
         try {

--- a/cadc-gms/src/test/java/org/opencadc/gms/GroupURITest.java
+++ b/cadc-gms/src/test/java/org/opencadc/gms/GroupURITest.java
@@ -24,10 +24,6 @@ public class GroupURITest {
         GroupURI uri1 = new GroupURI(URI.create("ivo://example.org/gms?name"));
         GroupURI uri2 = new GroupURI(URI.create("ivo://example.org/gms?name"));
         Assert.assertTrue(uri1.equals(uri2));
-
-        uri1 = new GroupURI(URI.create("ivo://example.org/gms?name"));
-        uri2 = new GroupURI(URI.create("ivo://example.org/gms#name")); // backwards compat only
-        Assert.assertTrue(uri1.equals(uri2));
     }
 
     @Test
@@ -44,6 +40,13 @@ public class GroupURITest {
 
             // no path
             assertIllegalArgument("ivo://example.org/gname", "name");
+            
+            // group name in fragment no longer allowed
+            assertIllegalArgument("ivo://my.authority/gms#name", "name");
+            
+            // fragment not allowed
+            assertIllegalArgument("ivo://my.authority/gms?name#name", "fragment");
+            
         } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);
             Assert.fail("unexpected exception: " + unexpected);
@@ -51,7 +54,7 @@ public class GroupURITest {
     }
 
     @Test
-    public void testCorrect1() {
+    public void testSimpleGroupName() {
         try {
             GroupURI g = new GroupURI("ivo://my.authority/gms?name");
             Assert.assertEquals("ivo", g.getURI().getScheme());
@@ -66,14 +69,15 @@ public class GroupURITest {
     }
 
     @Test
-    public void testCorrect2() {
+    public void testHierarchicalGroupName() {
         try {
-            GroupURI g = new GroupURI("ivo://my.authority/gms#name");
+            String name = "hierachical/group/structure";
+            GroupURI g = new GroupURI("ivo://my.authority/gms?" + name);
             Assert.assertEquals("ivo", g.getURI().getScheme());
             Assert.assertEquals("/gms", g.getURI().getPath());
-            Assert.assertEquals("name", g.getName());
+            Assert.assertEquals(name, g.getName());
             Assert.assertEquals("ivo://my.authority/gms", g.getServiceID().toASCIIString());
-            Assert.assertEquals("ivo://my.authority/gms?name", g.getURI().toASCIIString());
+            Assert.assertEquals("ivo://my.authority/gms?" + name, g.getURI().toASCIIString());
         } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);
             Assert.fail("unexpected exception: " + unexpected);


### PR DESCRIPTION
update StandardIdentityManager to add a trusted GMS host to oidcDomains 
deprecate old GroupCLient interface