### PR TITLE
Remove ready() call when using BufferedReader.

### DIFF
--- a/cadc-gms/build.gradle
+++ b/cadc-gms/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.0.11'
+version = '1.0.12'
 
 description = 'OpenCADC GMS API library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-gms/src/main/java/org/opencadc/auth/PosixMapperClient.java
+++ b/cadc-gms/src/main/java/org/opencadc/auth/PosixMapperClient.java
@@ -248,7 +248,7 @@ public class PosixMapperClient {
             @Override
             public boolean hasNext() {
                 try {
-                    return reader.ready() && (line = reader.readLine()) != null;
+                    return (line = reader.readLine()) != null;
                 } catch (IOException ioException) {
                     throw new RuntimeException(ioException.getMessage(), ioException);
                 }
@@ -293,7 +293,7 @@ public class PosixMapperClient {
             @Override
             public boolean hasNext() {
                 try {
-                    return reader.ready() && (line = reader.readLine()) != null;
+                    return (line = reader.readLine()) != null;
                 } catch (IOException ioException) {
                     throw new RuntimeException(ioException.getMessage(), ioException);
                 }


### PR DESCRIPTION
The ready() call will return false when the buffer empties, even though the buffer will fill up again afterward, so the results are truncated.