### PR TITLE
bug fix: detect required augment more carefully

### DIFF
--- a/cadc-access-control-identity/README.md
+++ b/cadc-access-control-identity/README.md
@@ -6,3 +6,11 @@ IdentityManager is configured in services as
 ```
 ca.nrc.cadc.auth.IdentityManager=ca.nrc.cadc.ac.ACIdentityManager
 ```
+
+If a service depends on having a complete PosixPrincipal (including the optional
+defaultGroup and username), it should set this additional system property:
+```
+ca.nrc.cadc.ac.ACIdentityManager.requireCompletePosixPrincipal=true
+```
+WARNING: This will cause a remote call to obtain the additional info not included
+in cookies or bearer tokens, so only use if required.

--- a/cadc-access-control-identity/build.gradle
+++ b/cadc-access-control-identity/build.gradle
@@ -12,7 +12,7 @@ repositories {
 sourceCompatibility = 1.8
 group = 'org.opencadc'
 
-version = '1.2.2'
+version = '1.2.3'
 
 description = 'OpenCADC IdentityManager plugin library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-access-control-identity/src/main/java/ca/nrc/cadc/ac/ACIdentityManager.java
+++ b/cadc-access-control-identity/src/main/java/ca/nrc/cadc/ac/ACIdentityManager.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2023.                            (c) 2023.
+*  (c) 2024.                            (c) 2024.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -105,6 +105,9 @@ public class ACIdentityManager implements IdentityManager {
     private static final Logger log = Logger.getLogger(ACIdentityManager.class);
     
     private static final Set<URI> SEC_METHODS;
+    private static final String PP_PROP = ACIdentityManager.class.getName() + "requireCompletePosixPrincipal";
+    
+    private final boolean requireCompletePosixPrincipal;
     
     static {
         Set<URI> tmp = new TreeSet<>();
@@ -116,6 +119,7 @@ public class ACIdentityManager implements IdentityManager {
     }
     
     public ACIdentityManager() {
+        this.requireCompletePosixPrincipal = "true".equals(System.getProperty(PP_PROP));
     }
 
     @Override
@@ -140,8 +144,10 @@ public class ACIdentityManager implements IdentityManager {
         NumericPrincipal np = getNumericPrincipal(subject);
         boolean needAugment = np == null;
 
-        PosixPrincipal pp = getPosixPrincipal(subject);
-        needAugment = needAugment || (pp == null || pp.defaultGroup == null || pp.username == null); // missing or incomplete
+        if (requireCompletePosixPrincipal) {
+            PosixPrincipal pp = getPosixPrincipal(subject);
+            needAugment = needAugment || (pp == null || pp.defaultGroup == null || pp.username == null); // missing or incomplete
+        }
 
         if (!needAugment) {
             return subject;

--- a/cadc-access-control-identity/src/main/java/ca/nrc/cadc/ac/ACIdentityManager.java
+++ b/cadc-access-control-identity/src/main/java/ca/nrc/cadc/ac/ACIdentityManager.java
@@ -141,7 +141,7 @@ public class ACIdentityManager implements IdentityManager {
         boolean needAugment = np == null;
 
         PosixPrincipal pp = getPosixPrincipal(subject);
-        needAugment = needAugment || (pp == null || pp.defaultGroup != null || pp.username != null); // missing or incomplete
+        needAugment = needAugment || (pp == null || pp.defaultGroup == null || pp.username == null); // missing or incomplete
 
         if (!needAugment) {
             return subject;


### PR DESCRIPTION
this has the downside that it will cause augment subject to be done to fill in missing PosixPrincipal fields everywhere when in fact only cavern and skaha care about PosixPrincipal details

might need a way to mitigate this (at least temporarily) -- enable posix augment where needed