### PR TITLE
fix: dispense with single static client in favor of closing the client properly

### DIFF
--- a/posix-mapper/VERSION
+++ b/posix-mapper/VERSION
@@ -4,6 +4,6 @@
 # tags with and without build number so operators use the versioned
 # tag but we always keep a timestamped tag in case a semantic tag gets
 # replaced accidentally
-VER=0.3.0
+VER=0.3.1
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/posix-mapper/src/main/java/org/opencadc/posix/mapper/PosixClient.java
+++ b/posix-mapper/src/main/java/org/opencadc/posix/mapper/PosixClient.java
@@ -4,7 +4,6 @@ import org.opencadc.gms.GroupURI;
 import org.opencadc.posix.mapper.web.group.GroupWriter;
 import org.opencadc.posix.mapper.web.user.UserWriter;
 
-import java.util.List;
 
 public interface PosixClient {
     // Dummy scheme and authority for default groups.
@@ -24,9 +23,11 @@ public interface PosixClient {
 
     Group saveGroup(Group group) throws Exception;
 
-    boolean groupExist(GroupURI groupURI) throws Exception;
-
-    List<User> getUsers() throws Exception;
+    /**
+     * Close this client and release underlying resources.
+     * @throws Exception    Anything unexpected.
+     */
+    void close() throws Exception;
 
     /**
      * Write out all the User mappings to the given writer.  It is the responsibility of the implementation to

--- a/posix-mapper/src/main/java/org/opencadc/posix/mapper/Postgres.java
+++ b/posix-mapper/src/main/java/org/opencadc/posix/mapper/Postgres.java
@@ -2,6 +2,12 @@ package org.opencadc.posix.mapper;
 
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.TypedQuery;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
 import org.apache.log4j.Logger;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -9,20 +15,21 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.exception.ConstraintViolationException;
 import org.opencadc.posix.mapper.web.PosixInitAction;
 
-import java.util.*;
-import java.util.function.Function;
-
 public class Postgres {
 
-    final Logger LOGGER = Logger.getLogger(Postgres.class);
+    private static final Logger LOGGER = Logger.getLogger(Postgres.class);
     private static final String DEFAULT_JNDI = "java:comp/env/" + PosixInitAction.JNDI_DATASOURCE;
-
     private final List<Class<?>> entityClasses = new ArrayList<>();
+    private final String defaultSchema;
     private SessionFactory sessionFactory;
 
-    private final String defaultSchema;
+    private Postgres(final String defaultSchema) {
+        this.defaultSchema = defaultSchema;
+    }
 
-    private static final Logger log = Logger.getLogger(Postgres.class);
+    public static Postgres instance(final String defaultSchema) {
+        return new Postgres(defaultSchema);
+    }
 
     private Properties properties() {
         Properties properties = new Properties();
@@ -35,7 +42,7 @@ public class Postgres {
         properties.put("hibernate.format_sql", "true");
         properties.put("hibernate.hbm2ddl.auto", "validate");
         properties.put("hibernate.current_session_context_class",
-                       "org.hibernate.context.internal.ThreadLocalSessionContext");
+                       "org.hibernate.context.internal.JTASessionContext");
         return properties;
     }
 
@@ -48,25 +55,9 @@ public class Postgres {
         return configuration;
     }
 
-    private Postgres() {
-        this(null);
-    }
-
-    private Postgres(final String defaultSchema) {
-        this.defaultSchema = defaultSchema;
-    }
-
     public Postgres entityClass(Class<?>... entityClasses) {
         this.entityClasses.addAll(Arrays.asList(entityClasses));
         return this;
-    }
-
-    public static Postgres instance() {
-        return new Postgres();
-    }
-
-    public static Postgres instance(final String defaultSchema) {
-        return new Postgres(defaultSchema);
     }
 
     public Postgres build() {
@@ -79,9 +70,9 @@ public class Postgres {
         return this.sessionFactory.openSession();
     }
 
-    public void close(Session session) {
-        if (session != null && session.isOpen()) {
-            session.close();
+    public void close() {
+        if (this.sessionFactory != null) {
+            this.sessionFactory.close();
         }
     }
 
@@ -106,7 +97,7 @@ public class Postgres {
                 return val;
             });
         } catch (Exception e) {
-            log.error(e);
+            LOGGER.error(e);
             throw e;
         }
     }

--- a/posix-mapper/src/main/java/org/opencadc/posix/mapper/PostgresPosixClient.java
+++ b/posix-mapper/src/main/java/org/opencadc/posix/mapper/PostgresPosixClient.java
@@ -65,20 +65,18 @@
  *
  ************************************************************************
  */
+
 package org.opencadc.posix.mapper;
-
-
-import org.hibernate.query.Query;
-import org.opencadc.gms.GroupURI;
-import org.opencadc.posix.mapper.web.group.GroupWriter;
-import org.opencadc.posix.mapper.web.user.UserWriter;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import org.hibernate.query.Query;
+import org.opencadc.gms.GroupURI;
+import org.opencadc.posix.mapper.web.group.GroupWriter;
+import org.opencadc.posix.mapper.web.user.UserWriter;
 
 
 public class PostgresPosixClient implements PosixClient {
@@ -87,6 +85,16 @@ public class PostgresPosixClient implements PosixClient {
 
     public PostgresPosixClient(Postgres postgres) {
         this.postgres = postgres;
+    }
+
+    /**
+     * Closes this resource, relinquishing any underlying resources.  This function will close off the Postgres
+     * connection, and any related items.
+     */
+    public void close() {
+        if (this.postgres != null) {
+            this.postgres.close();
+        }
     }
 
     @Override
@@ -116,16 +124,6 @@ public class PostgresPosixClient implements PosixClient {
     @Override
     public Group saveGroup(Group group) {
         return postgres.save(group);
-    }
-
-    @Override
-    public boolean groupExist(GroupURI groupURI) {
-        return getGroup(groupURI) != null;
-    }
-
-    @Override
-    public List<User> getUsers() {
-        return postgres.inTransaction(session -> session.createQuery("from Users u", User.class).list());
     }
 
     @Override
@@ -160,7 +158,7 @@ public class PostgresPosixClient implements PosixClient {
             }
 
             if (uidConstraints.length > 0) {
-                if (queryBuilder.indexOf("where") > 0 ) {
+                if (queryBuilder.indexOf("where") > 0) {
                     queryBuilder.append(" or");
                 } else {
                     queryBuilder.append(" where");
@@ -205,7 +203,7 @@ public class PostgresPosixClient implements PosixClient {
             }
 
             if (gidConstraints.length > 0) {
-                if (queryBuilder.indexOf("where") > 0 ) {
+                if (queryBuilder.indexOf("where") > 0) {
                     queryBuilder.append(" or");
                 } else {
                     queryBuilder.append(" where");

--- a/posix-mapper/src/main/java/org/opencadc/posix/mapper/web/group/GetAction.java
+++ b/posix-mapper/src/main/java/org/opencadc/posix/mapper/web/group/GetAction.java
@@ -68,21 +68,28 @@
 
 package org.opencadc.posix.mapper.web.group;
 
-import org.opencadc.gms.GroupURI;
-import org.opencadc.posix.mapper.web.PosixMapperAction;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
+import org.opencadc.gms.GroupURI;
+import org.opencadc.posix.mapper.PosixClient;
+import org.opencadc.posix.mapper.web.PosixMapperAction;
 
 public class GetAction extends PosixMapperAction {
     @Override
     public void doAction() throws Exception {
         final GroupWriter groupWriter = getGroupWriter();
-        PosixMapperAction.POSIX_CLIENT.writeGroups(groupWriter, groupParameters().toArray(new GroupURI[0]),
-                                           gidParameters().toArray(new Integer[0]));
+        PosixClient posixClient = null;
+        try {
+            posixClient = getPosixClient();
+            posixClient.writeGroups(groupWriter, groupParameters().toArray(new GroupURI[0]),
+                                    gidParameters().toArray(new Integer[0]));
+        } finally {
+            if (posixClient != null) {
+                posixClient.close();
+            }
+        }
 
         syncOutput.getOutputStream().flush();
     }

--- a/posix-mapper/src/main/java/org/opencadc/posix/mapper/web/user/GetAction.java
+++ b/posix-mapper/src/main/java/org/opencadc/posix/mapper/web/user/GetAction.java
@@ -68,21 +68,29 @@
 
 package org.opencadc.posix.mapper.web.user;
 
-
-import org.opencadc.posix.mapper.web.PosixMapperAction;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.opencadc.posix.mapper.PosixClient;
+import org.opencadc.posix.mapper.web.PosixMapperAction;
 
 public class GetAction extends PosixMapperAction {
 
     @Override
     public void doAction() throws Exception {
         final UserWriter userWriter = getUserWriter();
-        PosixMapperAction.POSIX_CLIENT.writeUsers(userWriter, usernameParameters().toArray(new String[0]),
-                                          uidParameters().toArray(new Integer[0]));
+        PosixClient posixClient = null;
+        try {
+            posixClient = getPosixClient();
+            posixClient.writeUsers(userWriter, usernameParameters().toArray(new String[0]),
+                                   uidParameters().toArray(new Integer[0]));
+        } finally {
+            if (posixClient != null) {
+                posixClient.close();
+            }
+        }
+
         syncOutput.getOutputStream().flush();
     }
 


### PR DESCRIPTION
## Description
Fixing a memory leak with a single static client caused timing issues with the database availability, and was generally bad practice.

## Fix
Ensure the `SessionFactory` from `Hibernate` is closed properly.  This is the proper way to clean up resources that were being consumed.  Also removed unused methods.