### PR TITLE
Added secure LDAP port configuration (CADC-15779)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *RsaSignature*.key
 *.patch
 *.iml
+tmp

--- a/ac/README.md
+++ b/ac/README.md
@@ -27,6 +27,11 @@ See <a href="https://github.com/opencadc/core/tree/master/cadc-util">cadc-util</
 See <a href="https://github.com/opencadc/reg/tree/master/cadc-registry">cadc-registry</a>.
 Note: this configuration file will soon be deprecated in favour of using the `ac.properties` file.
 
+### ac-ldap-config.properties
+
+See <a href="https://github.com/opencadc/ac/tree/master/cadc-access-control-server">cadc-access-control-server</a>.
+Note: this configuration file will soon be deprecated in favour of using the `ac.properties` file.
+
 ### cadc-log.properties (optional)
 See <a href="https://github.com/opencadc/core/tree/master/cadc-log">cadc-log</a> for common
 dynamic logging control.
@@ -43,13 +48,27 @@ org.opencadc.ac.readUser = cn={user},ou={org},o={org},c={country}
 ```
 X.509 DNs of privileged users with read access to any group.
 
+### ac-group-names.properties
+
+See <a href="src/test/resources/ac-group-names.properties">ac-group-names.properties</a>.
+Note: this configuration file will soon be deprecated in favour of using the `ac.properties` file.
+
+### ac-oidc-clients.properties
+
+See <a href="../cadc-access-control-server/src/test/config/ac-oidc-clients.properties">ac-oidc-clients.properties</a>.
+Note: this configuration file will soon be deprecated in favour of using the `ac.properties` file.
+
+### ac-domains.properties
+
+Space-separated list of domains included in OIDC access tokens for single sign-on:
+```
+domains = domain1 domain2
+```
+Note: this configuration file will soon be deprecated in favour of using the `ac.properties` file.
+
 ## TODO
 ### technical debt
-This service currently uses other configuration files that will be deprecated in future releases:
-- ac-oidc-clients.properties
-- ac-ldap-config.properties
-- ac-domains.properties
-- ac-group-names.properties
+Several configuration files listed above will be consolidated into `ac.properties` in future releases.
 
 ## building it
 ```

--- a/ac/VERSION
+++ b/ac/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-VER=1.5.0
+VER=1.5.1
 TAGS="${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/ac/build.gradle
+++ b/ac/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'org.opencadc:cadc-rest:[1.3.10,)'
     implementation 'org.opencadc:cadc-log:[1.1.5,)'
     implementation 'org.opencadc:cadc-access-control:[1.1.31,)'
-    implementation 'org.opencadc:cadc-access-control-server:[1.3.39,)'
+    implementation 'org.opencadc:cadc-access-control-server:[1.3.40,)'
     implementation 'org.opencadc:cadc-vosi:[1.4.4,2.0)'
 
     testImplementation 'junit:junit:[4.0,)'

--- a/ac/src/test/resources/ac-ldap-config-admin.properties
+++ b/ac/src/test/resources/ac-ldap-config-admin.properties
@@ -30,7 +30,6 @@ unboundReadOnly.maxWait = 30000
 unboundReadOnly.createIfNeeded = false
 
 # server configuration -- applies to all servers
-dbrcHost = devLdap
 port = 636
 proxyUser = uid=4665,ou=Users,ou=ds,dc=canfar,dc=net
 usersDN = ou=Users,ou=ds,dc=canfar,dc=net

--- a/ac/src/test/resources/ac-ldap-config.properties
+++ b/ac/src/test/resources/ac-ldap-config.properties
@@ -30,7 +30,6 @@ unboundReadOnly.maxWait = 30000
 unboundReadOnly.createIfNeeded = false
 
 # server configuration -- applies to all servers
-dbrcHost = devLdap
 port = 636
 proxyUser = uid=webproxy,ou=SpecialUsers,dc=canfar,dc=net
 usersDN = ou=Users,ou=ds,dc=canfar,dc=net

--- a/cadc-access-control-admin/README.md
+++ b/cadc-access-control-admin/README.md
@@ -45,7 +45,6 @@ unboundReadOnly.maxWait = 30000
 unboundReadOnly.createIfNeeded = false
 
 ########## server configuration -- applies to all servers #####
-dbrcHost = devLdap
 port = 636
 proxyUser = uid=webproxy,ou=SpecialUsers,dc=canfar,dc=net
 proxyPassword = {webproxy ldap password}

--- a/cadc-access-control-server/.dbrc_example
+++ b/cadc-access-control-server/.dbrc_example
@@ -1,2 +1,2 @@
 #server	proxyuser proxyUserDN password driver serverURL
-<server hostname> <proxyUser in LdapConfig.properties> <proxyUserLdapDN> <password> N/A N/A
+<server hostname> <proxyUser in ac-ldap-config.properties> <proxyUserLdapDN> <password> N/A N/A

--- a/cadc-access-control-server/README.md
+++ b/cadc-access-control-server/README.md
@@ -44,7 +44,66 @@ relational database).
 ## CONFIGURATION
 
 The service requires the following configuration files:
-.dbrc: stores data source configuration for the LDAP server
-ldap.properties: stores LDAP connection configuration
+- `ac-ldap-config.properties`: stores LDAP connection and pool configuration
 
+### ac-ldap-config.properties
+
+This file configures connection to the back-end LDAP server. Three connection pools must be defined:
+read-only, read-write, and unbound read-only.
+
+```
+################## Read-only connection pool ##################
+# space separated list of hosts
+readOnly.servers = {ldap server}
+readOnly.port = 389
+readOnly.secure = false
+readOnly.poolInitSize = 1
+readOnly.poolMaxSize = 1
+# <roundRobin || fewestConnections || fastestConnect>
+readOnly.poolPolicy = roundRobin
+readOnly.maxWait = 30000
+readOnly.createIfNeeded = false
+
+################## Read-write connection pool #################
+# space separated list of hosts
+readWrite.servers = {ldap server}
+readWrite.port = 636
+readWrite.secure = true
+readWrite.poolInitSize = 1
+readWrite.poolMaxSize = 1
+# <roundRobin || fewestConnections>
+readWrite.poolPolicy = roundRobin
+readWrite.maxWait = 30000
+readWrite.createIfNeeded = false
+
+############## Unbound-Read-only connection pool ##############
+# space separated list of hosts
+unboundReadOnly.servers = {ldap server}
+unboundReadOnly.port = 636
+unboundReadOnly.secure = true
+unboundReadOnly.poolInitSize = 1
+unboundReadOnly.poolMaxSize = 1
+# <roundRobin || fewestConnections>
+unboundReadOnly.poolPolicy = roundRobin
+unboundReadOnly.maxWait = 30000
+unboundReadOnly.createIfNeeded = false
+
+########## server configuration -- applies to all servers #####
+port = 636
+proxyUser = uid=webproxy,ou=SpecialUsers,dc=canfar,dc=net
+proxyPassword = {webproxy ldap password}
+usersDN = ou=Users,ou=ds,dc=canfar,dc=net
+userRequestsDN = ou=userRequests,ou=ds,dc=canfar,dc=net
+groupsDN = ou=Groups,ou=ds,dc=canfar,dc=net
+adminGroupsDN = ou=adminGroups,ou=ds,dc=canfar,dc=net
+```
+
+Each pool may specify its own `port`. If omitted, the default `port` at the bottom of the file is used.
+
+Each pool may also specify `secure` to indicate whether connections use TLS. When omitted,
+`secure` defaults to `true` when the pool port is 636 and `false` otherwise. Set `secure = true`
+explicitly when using a non-standard port for LDAPS (for example, `readOnly.port = 10636` with
+`readOnly.secure = true`).
+
+See also [ac-ldap-config.properties](ac-ldap-config.properties) for a template with all supported keys.
 

--- a/cadc-access-control-server/ac-ldap-config.properties
+++ b/cadc-access-control-server/ac-ldap-config.properties
@@ -13,6 +13,7 @@ readOnly.poolPolicy = <roundRobin || fewestConnections || fastestConnect>
 readOnly.maxWait = <timeout wait time in milliseconds>
 readOnly.createIfNeeded = <true || false> Go beyond poolMaxSize
 readOnly.port = <optional, 389 || 636 || omit for default (parent) port >
+readOnly.secure = <optional, true || false; defaults to true when port is 636, false otherwise>
 
 # Read-write connection pool
 readWrite.servers = <list of ldap servers for readwrite access>
@@ -22,6 +23,7 @@ readWrite.poolPolicy = <roundRobin || fewestConnections>
 readWrite.maxWait = <timeout wait time in milliseconds>
 readWrite.createIfNeeded = <true || false> Go beyond poolMaxSize
 readWrite.port = <optional, 389 || 636 || omit for default (parent) port >
+readWrite.secure = <optional, true || false; defaults to true when port is 636, false otherwise>
 
 # Unbound-Read-only connection pool
 unboundReadOnly.servers = <list of ldap servers for readonly unbound access>
@@ -31,9 +33,9 @@ unboundReadOnly.poolPolicy = <roundRobin || fewestConnections>
 unboundReadOnly.maxWait = <timeout wait time in milliseconds>
 unboundReadOnly.createIfNeeded = <true || false> Go beyond poolMaxSize
 unboundReadOnly.port = <optional, 389 || 636 || omit for default (parent) port >
+unboundReadOnly.secure = <optional, true || false; defaults to true when port is 636, false otherwise>
 
 # server configuration -- applies to all servers
-dbrcHost = <prodLdap || devLdap>
 port = <389 or 636>
 proxyUser = <name of proxy user>
 proxyPassword = <password of proxy user>

--- a/cadc-access-control-server/build.gradle
+++ b/cadc-access-control-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 11
 
 group = 'org.opencadc'
 
-version = '1.3.39'
+version = '1.3.40'
 
 description = 'OpenCADC User+Group server library'
 def git_url = 'https://github.com/opencadc/ac'

--- a/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/ldap/LdapConfig.java
+++ b/cadc-access-control-server/src/main/java/ca/nrc/cadc/ac/server/ldap/LdapConfig.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2023.                            (c) 2023.
+ *  (c) 2026.                            (c) 2026.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -72,7 +72,9 @@ package ca.nrc.cadc.ac.server.ldap;
 import ca.nrc.cadc.util.MultiValuedProperties;
 import ca.nrc.cadc.util.PropertiesReader;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceConfigurationError;
 import org.apache.log4j.Logger;
 
@@ -96,6 +98,7 @@ public class LdapConfig {
     public static final String POOL_MAX_SIZE = "poolMaxSize";
     public static final String POOL_POLICY = "poolPolicy";
     public static final String POOL_PORT = "port";
+    public static final String POOL_SECURE = "secure";
     public static final String MAX_WAIT = "maxWait";
     public static final String CREATE_IF_NEEDED = "createIfNeeded";
 
@@ -107,7 +110,7 @@ public class LdapConfig {
     public static final String LDAP_GROUPS_DN = "groupsDN";
     public static final String LDAP_ADMIN_GROUPS_DN = "adminGroupsDN";
 
-    private final static int SECURE_PORT = 636;
+    private static final int SECURE_PORT = 636;
 
     public enum PoolPolicy {
         roundRobin,
@@ -126,6 +129,7 @@ public class LdapConfig {
         private int initSize;
         private int maxSize;
         private int port;
+        private boolean secure;
         private PoolPolicy policy;
         private long maxWait;
         private boolean createIfNeeded;
@@ -151,7 +155,7 @@ public class LdapConfig {
         }
 
         public boolean isSecure() {
-            return getPort() == SECURE_PORT;
+            return secure;
         }
 
         public long getMaxWait() {
@@ -170,6 +174,7 @@ public class LdapConfig {
                 sb.append(" [" + server + "]");
             }
             sb.append(" port: " + port);
+            sb.append(" secure: " + secure);
             sb.append(" initSize: " + initSize);
             sb.append(" maxSize: " + maxSize);
             sb.append(" policy: " + policy);
@@ -180,37 +185,47 @@ public class LdapConfig {
 
         @Override
         public boolean equals(Object other) {
-            if (other == null || !(other instanceof LdapPool))
+            if (other == null || !(other instanceof LdapPool)) {
                 return false;
+            }
 
             LdapPool l = (LdapPool) other;
 
-            if (l.port != port)
+            if (l.port != port) {
                 return false;
+            }
 
-            if (!l.servers.equals(servers))
+            if (l.secure != secure) {
                 return false;
+            }
 
-            if (l.initSize != initSize)
+            if (!l.servers.equals(servers)) {
                 return false;
+            }
 
-            if (l.maxSize != maxSize)
+            if (l.initSize != initSize) {
                 return false;
+            }
 
-            if (!(l.policy.equals(policy)))
+            if (l.maxSize != maxSize) {
                 return false;
+            }
 
-            if (!(l.maxWait == maxWait))
+            if (!(l.policy.equals(policy))) {
                 return false;
+            }
 
-            if (!(l.createIfNeeded == createIfNeeded))
+            if (!(l.maxWait == maxWait)) {
                 return false;
+            }
+
+            if (!(l.createIfNeeded == createIfNeeded)) {
+                return false;
+            }
 
             return true;
         }
     }
-
-    ;
 
     private LdapPool readOnlyPool = new LdapPool();
     private LdapPool readWritePool = new LdapPool();
@@ -251,6 +266,8 @@ public class LdapConfig {
         loadPoolConfig(ldapConfig.readWritePool, config, READWRITE_PREFIX);
         loadPoolConfig(ldapConfig.unboundReadOnlyPool, config, UB_READONLY_PREFIX);
 
+        validatePortSecureConsistency(ldapConfig);
+
         String defaultPort = config.getFirstPropertyValue(DEFAULT_LDAP_PORT);
         if (defaultPort != null) {
             ldapConfig.defaultPort = Integer.parseInt(defaultPort);
@@ -273,8 +290,8 @@ public class LdapConfig {
         pool.maxSize = Integer.parseInt(getProperty(pr, prefix + POOL_MAX_SIZE));
         pool.policy = PoolPolicy.valueOf(getProperty(pr, prefix + POOL_POLICY));
 
-        // Set the port to use for this pool's servers.  Default to the parent port config so that the isSecure()
-        // method still works.  Throw an Exception if no port found.
+        // Set the port to use for this pool's servers.  Default to the parent port config.  Throw an Exception
+        // if no port found.
         String port = pr.getFirstPropertyValue(prefix + POOL_PORT);
         if (port != null) {
             pool.port = Integer.parseInt(port);
@@ -287,13 +304,44 @@ public class LdapConfig {
                 pool.port = Integer.parseInt(port);
             }
         }
+        String secure = pr.getFirstPropertyValue(prefix + POOL_SECURE);
+        if (secure != null) {
+            pool.secure = Boolean.parseBoolean(secure);
+        } else {
+            pool.secure = pool.port == SECURE_PORT;
+        }
         if (pool.policy == PoolPolicy.fastestConnect && !prefix.equals(READONLY_PREFIX)) {
-            throw new ServiceConfigurationError(PoolPolicy.fastestConnect.toString() +
-                    " pool policy cannot be applied to " +
-                    prefix.substring(0, prefix.length() - 1) + " pool servers.");
+            throw new ServiceConfigurationError(PoolPolicy.fastestConnect.toString()
+                    + " pool policy cannot be applied to "
+                    + prefix.substring(0, prefix.length() - 1) + " pool servers.");
         }
         pool.maxWait = Long.parseLong(getProperty(pr, prefix + MAX_WAIT));
         pool.createIfNeeded = Boolean.parseBoolean(getProperty(pr, prefix + CREATE_IF_NEEDED));
+    }
+
+    private static void validatePortSecureConsistency(LdapConfig ldapConfig) {
+        Map<Integer, Boolean> portSecure = new HashMap<Integer, Boolean>();
+        Map<Integer, String> portPool = new HashMap<Integer, String>();
+        checkPoolPortSecure(READONLY_PREFIX, ldapConfig.getReadOnlyPool(), portSecure, portPool);
+        checkPoolPortSecure(READWRITE_PREFIX, ldapConfig.getReadWritePool(), portSecure, portPool);
+        checkPoolPortSecure(UB_READONLY_PREFIX, ldapConfig.getUnboundReadOnlyPool(), portSecure, portPool);
+    }
+
+    private static void checkPoolPortSecure(String prefix, LdapPool pool,
+            Map<Integer, Boolean> portSecure, Map<Integer, String> portPool) {
+        int port = pool.getPort();
+        boolean secure = pool.isSecure();
+        String poolName = prefix.substring(0, prefix.length() - 1);
+        if (portSecure.containsKey(port)) {
+            if (portSecure.get(port).booleanValue() != secure) {
+                throw new ServiceConfigurationError("Inconsistent secure setting for port " + port + ": "
+                        + portPool.get(port) + " has secure=" + portSecure.get(port)
+                        + " but " + poolName + " has secure=" + secure);
+            }
+        } else {
+            portSecure.put(port, secure);
+            portPool.put(port, poolName);
+        }
     }
 
     private static String getProperty(MultiValuedProperties properties, String key) {
@@ -331,40 +379,60 @@ public class LdapConfig {
         return SystemState.ONLINE;
     }
 
+    /**
+     * Check if in read-only or offline mode.
+     *
+     * <p>A read max connection size of zero implies offline mode.
+     * A read-wrtie max connection size of zero implies read-only mode.
+     */
+    public SystemState getSystemState() {
+        return systemState;
+    }
+
 
     @Override
     public boolean equals(Object other) {
-        if (other == null || !(other instanceof LdapConfig))
+        if (other == null || !(other instanceof LdapConfig)) {
             return false;
+        }
 
         LdapConfig l = (LdapConfig) other;
 
-        if (!(l.defaultPort == defaultPort))
+        if (!(l.defaultPort == defaultPort)) {
             return false;
+        }
 
-        if (!(l.usersDN.equals(usersDN)))
+        if (!(l.usersDN.equals(usersDN))) {
             return false;
+        }
 
-        if (!(l.userRequestsDN.equals(userRequestsDN)))
+        if (!(l.userRequestsDN.equals(userRequestsDN))) {
             return false;
+        }
 
-        if (!(l.groupsDN.equals(groupsDN)))
+        if (!(l.groupsDN.equals(groupsDN))) {
             return false;
+        }
 
-        if (!(l.adminGroupsDN.equals(adminGroupsDN)))
+        if (!(l.adminGroupsDN.equals(adminGroupsDN))) {
             return false;
+        }
 
-        if (!(l.proxyUserDN.equals(proxyUserDN)))
+        if (!(l.proxyUserDN.equals(proxyUserDN))) {
             return false;
+        }
 
-        if (!(l.readOnlyPool.equals(readOnlyPool)))
+        if (!(l.readOnlyPool.equals(readOnlyPool))) {
             return false;
+        }
 
-        if (!(l.readWritePool.equals(readWritePool)))
+        if (!(l.readWritePool.equals(readWritePool))) {
             return false;
+        }
 
-        if (!(l.unboundReadOnlyPool.equals(unboundReadOnlyPool)))
+        if (!(l.unboundReadOnlyPool.equals(unboundReadOnlyPool))) {
             return false;
+        }
 
         return true;
     }
@@ -410,16 +478,6 @@ public class LdapConfig {
 
     public String getAdminPasswd() {
         return this.proxyPasswd;
-    }
-
-    /**
-     * Check if in read-only or offline mode.
-     * <p>
-     * A read max connection size of zero implies offline mode.
-     * A read-wrtie max connection size of zero implies read-only mode.
-     */
-    public SystemState getSystemState() {
-        return systemState;
     }
 
     public String toString() {

--- a/cadc-access-control-server/src/test/config/testConfig.secure-port.properties
+++ b/cadc-access-control-server/src/test/config/testConfig.secure-port.properties
@@ -1,38 +1,41 @@
 ###############################################################
 #
-# Test ldap config #1
-#
+# Test ldap config with non-default secure port
 #
 ###############################################################
 
 # Read-only connection pool
-readOnly.servers = server1 server2 server3
-readOnly.poolInitSize = 3
-readOnly.poolMaxSize = 8
+readOnly.servers = server1
+readOnly.port = 10636
+readOnly.secure = true
+readOnly.poolInitSize = 1
+readOnly.poolMaxSize = 2
 readOnly.poolPolicy = roundRobin
 readOnly.maxWait = 30000
 readOnly.createIfNeeded = false
 
 # Read-write connection pool
-readWrite.servers = server4 server5
-readWrite.poolInitSize = 4
-readWrite.poolMaxSize = 9
+readWrite.servers = server2
+readWrite.port = 389
+readWrite.secure = false
+readWrite.poolInitSize = 1
+readWrite.poolMaxSize = 2
 readWrite.poolPolicy = fewestConnections
 readWrite.maxWait = 30000
 readWrite.createIfNeeded = false
 
 # Unbound-Read-only connection pool
-unboundReadOnly.servers = server1 server2 server3
-unboundReadOnly.poolInitSize = 3
-unboundReadOnly.poolMaxSize = 8
+unboundReadOnly.servers = server1
+unboundReadOnly.port = 10636
+unboundReadOnly.secure = true
+unboundReadOnly.poolInitSize = 1
+unboundReadOnly.poolMaxSize = 2
 unboundReadOnly.poolPolicy = roundRobin
 unboundReadOnly.maxWait = 30000
 unboundReadOnly.createIfNeeded = false
 
-# server configuration -- applies to all servers
-dbrcHost = devLdap
-port = 389
 proxyUser = uid=testuser,ou=testorg,dc=test
+proxyPassword = 123456
 usersDN = usersDN
 userRequestsDN = userRequestsDN
 groupsDN = groupsDN

--- a/cadc-access-control-server/src/test/config/testConfig.shared-port-implicit-mismatch.properties
+++ b/cadc-access-control-server/src/test/config/testConfig.shared-port-implicit-mismatch.properties
@@ -1,0 +1,38 @@
+###############################################################
+#
+# readOnly uses default port 10636 (implicit secure=false);
+# unboundReadOnly uses same port with explicit secure=true
+#
+###############################################################
+
+readOnly.servers = server1
+readOnly.poolInitSize = 1
+readOnly.poolMaxSize = 2
+readOnly.poolPolicy = roundRobin
+readOnly.maxWait = 30000
+readOnly.createIfNeeded = false
+
+readWrite.servers = server2
+readWrite.port = 389
+readWrite.poolInitSize = 1
+readWrite.poolMaxSize = 2
+readWrite.poolPolicy = fewestConnections
+readWrite.maxWait = 30000
+readWrite.createIfNeeded = false
+
+unboundReadOnly.servers = server1
+unboundReadOnly.port = 10636
+unboundReadOnly.secure = true
+unboundReadOnly.poolInitSize = 1
+unboundReadOnly.poolMaxSize = 2
+unboundReadOnly.poolPolicy = roundRobin
+unboundReadOnly.maxWait = 30000
+unboundReadOnly.createIfNeeded = false
+
+port = 10636
+proxyUser = uid=testuser,ou=testorg,dc=test
+proxyPassword = 123456
+usersDN = usersDN
+userRequestsDN = userRequestsDN
+groupsDN = groupsDN
+adminGroupsDN = adminGroupsDN

--- a/cadc-access-control-server/src/test/config/testConfig.shared-port-insecure-ro-ub.properties
+++ b/cadc-access-control-server/src/test/config/testConfig.shared-port-insecure-ro-ub.properties
@@ -1,0 +1,38 @@
+###############################################################
+#
+# readOnly and unboundReadOnly share port 10636 with inconsistent secure
+#
+###############################################################
+
+readOnly.servers = server1
+readOnly.port = 10636
+readOnly.secure = true
+readOnly.poolInitSize = 1
+readOnly.poolMaxSize = 2
+readOnly.poolPolicy = roundRobin
+readOnly.maxWait = 30000
+readOnly.createIfNeeded = false
+
+readWrite.servers = server2
+readWrite.port = 389
+readWrite.poolInitSize = 1
+readWrite.poolMaxSize = 2
+readWrite.poolPolicy = fewestConnections
+readWrite.maxWait = 30000
+readWrite.createIfNeeded = false
+
+unboundReadOnly.servers = server1
+unboundReadOnly.port = 10636
+unboundReadOnly.secure = false
+unboundReadOnly.poolInitSize = 1
+unboundReadOnly.poolMaxSize = 2
+unboundReadOnly.poolPolicy = roundRobin
+unboundReadOnly.maxWait = 30000
+unboundReadOnly.createIfNeeded = false
+
+proxyUser = uid=testuser,ou=testorg,dc=test
+proxyPassword = 123456
+usersDN = usersDN
+userRequestsDN = userRequestsDN
+groupsDN = groupsDN
+adminGroupsDN = adminGroupsDN

--- a/cadc-access-control-server/src/test/config/testConfig.shared-port-insecure-rw-ub.properties
+++ b/cadc-access-control-server/src/test/config/testConfig.shared-port-insecure-rw-ub.properties
@@ -1,0 +1,38 @@
+###############################################################
+#
+# readWrite and unboundReadOnly share port 10636 with inconsistent secure
+#
+###############################################################
+
+unboundReadOnly.servers = server1
+unboundReadOnly.port = 10636
+unboundReadOnly.secure = false
+unboundReadOnly.poolInitSize = 1
+unboundReadOnly.poolMaxSize = 2
+unboundReadOnly.poolPolicy = roundRobin
+unboundReadOnly.maxWait = 30000
+unboundReadOnly.createIfNeeded = false
+
+readWrite.servers = server2
+readWrite.port = 10636
+readWrite.secure = true
+readWrite.poolInitSize = 1
+readWrite.poolMaxSize = 2
+readWrite.poolPolicy = fewestConnections
+readWrite.maxWait = 30000
+readWrite.createIfNeeded = false
+
+readOnly.servers = server3
+readOnly.port = 389
+readOnly.poolInitSize = 1
+readOnly.poolMaxSize = 2
+readOnly.poolPolicy = roundRobin
+readOnly.maxWait = 30000
+readOnly.createIfNeeded = false
+
+proxyUser = uid=testuser,ou=testorg,dc=test
+proxyPassword = 123456
+usersDN = usersDN
+userRequestsDN = userRequestsDN
+groupsDN = groupsDN
+adminGroupsDN = adminGroupsDN

--- a/cadc-access-control-server/src/test/config/testConfig.shared-port-secure-alt-order.properties
+++ b/cadc-access-control-server/src/test/config/testConfig.shared-port-secure-alt-order.properties
@@ -1,0 +1,38 @@
+###############################################################
+#
+# Same as shared-port-secure with pool sections in different order
+#
+###############################################################
+
+unboundReadOnly.servers = server1
+unboundReadOnly.port = 10636
+unboundReadOnly.secure = true
+unboundReadOnly.poolInitSize = 1
+unboundReadOnly.poolMaxSize = 2
+unboundReadOnly.poolPolicy = roundRobin
+unboundReadOnly.maxWait = 30000
+unboundReadOnly.createIfNeeded = false
+
+readOnly.servers = server1
+readOnly.port = 10636
+readOnly.secure = true
+readOnly.poolInitSize = 1
+readOnly.poolMaxSize = 2
+readOnly.poolPolicy = roundRobin
+readOnly.maxWait = 30000
+readOnly.createIfNeeded = false
+
+readWrite.servers = server2
+readWrite.port = 389
+readWrite.poolInitSize = 1
+readWrite.poolMaxSize = 2
+readWrite.poolPolicy = fewestConnections
+readWrite.maxWait = 30000
+readWrite.createIfNeeded = false
+
+proxyUser = uid=testuser,ou=testorg,dc=test
+proxyPassword = 123456
+usersDN = usersDN
+userRequestsDN = userRequestsDN
+groupsDN = groupsDN
+adminGroupsDN = adminGroupsDN

--- a/cadc-access-control-server/src/test/config/testConfig.shared-port-secure.properties
+++ b/cadc-access-control-server/src/test/config/testConfig.shared-port-secure.properties
@@ -1,0 +1,38 @@
+###############################################################
+#
+# Pools share port 10636 with consistent secure=true
+#
+###############################################################
+
+readWrite.servers = server2
+readWrite.port = 389
+readWrite.poolInitSize = 1
+readWrite.poolMaxSize = 2
+readWrite.poolPolicy = fewestConnections
+readWrite.maxWait = 30000
+readWrite.createIfNeeded = false
+
+readOnly.servers = server1
+readOnly.port = 10636
+readOnly.secure = true
+readOnly.poolInitSize = 1
+readOnly.poolMaxSize = 2
+readOnly.poolPolicy = roundRobin
+readOnly.maxWait = 30000
+readOnly.createIfNeeded = false
+
+unboundReadOnly.servers = server1
+unboundReadOnly.port = 10636
+unboundReadOnly.secure = true
+unboundReadOnly.poolInitSize = 1
+unboundReadOnly.poolMaxSize = 2
+unboundReadOnly.poolPolicy = roundRobin
+unboundReadOnly.maxWait = 30000
+unboundReadOnly.createIfNeeded = false
+
+proxyUser = uid=testuser,ou=testorg,dc=test
+proxyPassword = 123456
+usersDN = usersDN
+userRequestsDN = userRequestsDN
+groupsDN = groupsDN
+adminGroupsDN = adminGroupsDN

--- a/cadc-access-control-server/src/test/java/ca/nrc/cadc/ac/server/ldap/LdapConfigTest.java
+++ b/cadc-access-control-server/src/test/java/ca/nrc/cadc/ac/server/ldap/LdapConfigTest.java
@@ -1,68 +1,70 @@
-/**
- * ***********************************************************************
- * ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
- * *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
- * <p>
- * (c) 2023.                            (c) 2023.
- * Government of Canada                 Gouvernement du Canada
- * National Research Council            Conseil national de recherches
- * Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
- * All rights reserved                  Tous droits réservés
- * <p>
- * NRC disclaims any warranties,        Le CNRC dénie toute garantie
- * expressed, implied, or               énoncée, implicite ou légale,
- * statutory, of any kind with          de quelque nature que ce
- * respect to the software,             soit, concernant le logiciel,
- * including without limitation         y compris sans restriction
- * any warranty of merchantability      toute garantie de valeur
- * or fitness for a particular          marchande ou de pertinence
- * purpose. NRC shall not be            pour un usage particulier.
- * liable in any event for any          Le CNRC ne pourra en aucun cas
- * damages, whether direct or           être tenu responsable de tout
- * indirect, special or general,        dommage, direct ou indirect,
- * consequential or incidental,         particulier ou général,
- * arising from the use of the          accessoire ou fortuit, résultant
- * software.  Neither the name          de l'utilisation du logiciel. Ni
- * of the National Research             le nom du Conseil National de
- * Council of Canada nor the            Recherches du Canada ni les noms
- * names of its contributors may        de ses  participants ne peuvent
- * be used to endorse or promote        être utilisés pour approuver ou
- * products derived from this           promouvoir les produits dérivés
- * software without specific prior      de ce logiciel sans autorisation
- * written permission.                  préalable et particulière
- * par écrit.
- * <p>
- * This file is part of the             Ce fichier fait partie du projet
- * OpenCADC project.                    OpenCADC.
- * <p>
- * OpenCADC is free software:           OpenCADC est un logiciel libre ;
- * you can redistribute it and/or       vous pouvez le redistribuer ou le
- * modify it under the terms of         modifier suivant les termes de
- * the GNU Affero General Public        la “GNU Affero General Public
- * License as published by the          License” telle que publiée
- * Free Software Foundation,            par la Free Software Foundation
- * either version 3 of the              : soit la version 3 de cette
- * License, or (at your option)         licence, soit (à votre gré)
- * any later version.                   toute version ultérieure.
- * <p>
- * OpenCADC is distributed in the       OpenCADC est distribué
- * hope that it will be useful,         dans l’espoir qu’il vous
- * but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
- * without even the implied             GARANTIE : sans même la garantie
- * warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
- * or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
- * PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
- * General Public License for           Générale Publique GNU Affero
- * more details.                        pour plus de détails.
- * <p>
- * You should have received             Vous devriez avoir reçu une
- * a copy of the GNU Affero             copie de la Licence Générale
- * General Public License along         Publique GNU Affero avec
- * with OpenCADC.  If not, see          OpenCADC ; si ce n’est
- * <http://www.gnu.org/licenses/>.      pas le cas, consultez :
- * <http://www.gnu.org/licenses/>.
- * <p>
- * ***********************************************************************
+/*
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2026.                            (c) 2026.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 4 $
+ *
+ ************************************************************************
  */
 
 package ca.nrc.cadc.ac.server.ldap;
@@ -72,6 +74,7 @@ import ca.nrc.cadc.ac.server.ldap.LdapConfig.SystemState;
 import ca.nrc.cadc.util.Log4jInit;
 import ca.nrc.cadc.util.PropertiesReader;
 import java.util.Arrays;
+import java.util.ServiceConfigurationError;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
@@ -87,6 +90,15 @@ public class LdapConfigTest {
         Log4jInit.setLevel("ca.nrc.cadc.ac", Level.INFO);
     }
 
+    private void setTestConfigDir() {
+        System.setProperty(PropertiesReader.class.getName() + ".dir", "src/test/config");
+        System.setProperty("user.home", "src/test/config");
+    }
+
+    private void clearTestConfigDir() {
+        System.clearProperty(PropertiesReader.class.getName() + ".dir");
+    }
+
     @Test
     public void testLoadConfig1() {
         try {
@@ -95,8 +107,11 @@ public class LdapConfigTest {
 
             LdapConfig c = LdapConfig.loadLdapConfig("testConfig1.properties");
             Assert.assertEquals(389, c.getReadOnlyPool().getPort());
+            Assert.assertEquals(false, c.getReadOnlyPool().isSecure());
             Assert.assertEquals(636, c.getReadWritePool().getPort());
+            Assert.assertEquals(true, c.getReadWritePool().isSecure());
             Assert.assertEquals(636, c.getUnboundReadOnlyPool().getPort());
+            Assert.assertEquals(true, c.getUnboundReadOnlyPool().isSecure());
             Assert.assertEquals("uid=testuser,ou=testorg,dc=test", c.getProxyUserDN());
             Assert.assertEquals("usersDN", c.getUsersDN());
             Assert.assertEquals("userRequestsDN", c.getUserRequestsDN());
@@ -214,6 +229,109 @@ public class LdapConfigTest {
             Assert.fail("Unexpected exception: " + t.getMessage());
         } finally {
             System.clearProperty(PropertiesReader.class.getName() + ".dir");
+        }
+    }
+
+    @Test
+    public void testLoadSecurePortConfig() {
+        try {
+            System.setProperty(PropertiesReader.class.getName() + ".dir", "src/test/config");
+            System.setProperty("user.home", "src/test/config");
+
+            LdapConfig c = LdapConfig.loadLdapConfig("testConfig.secure-port.properties");
+            Assert.assertEquals(10636, c.getReadOnlyPool().getPort());
+            Assert.assertTrue(c.getReadOnlyPool().isSecure());
+            Assert.assertEquals(389, c.getReadWritePool().getPort());
+            Assert.assertFalse(c.getReadWritePool().isSecure());
+            Assert.assertEquals(10636, c.getUnboundReadOnlyPool().getPort());
+            Assert.assertTrue(c.getUnboundReadOnlyPool().isSecure());
+        } catch (Throwable t) {
+            log.error("Unexpected exception", t);
+            Assert.fail("Unexpected exception: " + t.getMessage());
+        } finally {
+            System.clearProperty(PropertiesReader.class.getName() + ".dir");
+        }
+    }
+
+    @Test
+    public void testSharedPortSecureConsistent() {
+        try {
+            setTestConfigDir();
+            LdapConfig c = LdapConfig.loadLdapConfig("testConfig.shared-port-secure.properties");
+            Assert.assertEquals(10636, c.getReadOnlyPool().getPort());
+            Assert.assertTrue(c.getReadOnlyPool().isSecure());
+            Assert.assertEquals(10636, c.getUnboundReadOnlyPool().getPort());
+            Assert.assertTrue(c.getUnboundReadOnlyPool().isSecure());
+        } catch (Throwable t) {
+            log.error("Unexpected exception", t);
+            Assert.fail("Unexpected exception: " + t.getMessage());
+        } finally {
+            clearTestConfigDir();
+        }
+    }
+
+    @Test
+    public void testSharedPortSecureConsistentAltOrder() {
+        try {
+            setTestConfigDir();
+            LdapConfig c = LdapConfig.loadLdapConfig("testConfig.shared-port-secure-alt-order.properties");
+            Assert.assertEquals(10636, c.getReadOnlyPool().getPort());
+            Assert.assertTrue(c.getReadOnlyPool().isSecure());
+            Assert.assertEquals(10636, c.getUnboundReadOnlyPool().getPort());
+            Assert.assertTrue(c.getUnboundReadOnlyPool().isSecure());
+        } catch (Throwable t) {
+            log.error("Unexpected exception", t);
+            Assert.fail("Unexpected exception: " + t.getMessage());
+        } finally {
+            clearTestConfigDir();
+        }
+    }
+
+    @Test
+    public void testSharedPortSecureInconsistentReadOnlyUnbound() {
+        try {
+            setTestConfigDir();
+            LdapConfig.loadLdapConfig("testConfig.shared-port-insecure-ro-ub.properties");
+            Assert.fail("Expected ServiceConfigurationError for inconsistent secure on shared port");
+        } catch (ServiceConfigurationError expected) {
+            Assert.assertTrue(expected.getMessage().contains("Inconsistent secure setting for port 10636"));
+        } catch (Throwable t) {
+            log.error("Unexpected exception", t);
+            Assert.fail("Unexpected exception: " + t.getMessage());
+        } finally {
+            clearTestConfigDir();
+        }
+    }
+
+    @Test
+    public void testSharedPortSecureInconsistentReadWriteUnbound() {
+        try {
+            setTestConfigDir();
+            LdapConfig.loadLdapConfig("testConfig.shared-port-insecure-rw-ub.properties");
+            Assert.fail("Expected ServiceConfigurationError for inconsistent secure on shared port");
+        } catch (ServiceConfigurationError expected) {
+            Assert.assertTrue(expected.getMessage().contains("Inconsistent secure setting for port 10636"));
+        } catch (Throwable t) {
+            log.error("Unexpected exception", t);
+            Assert.fail("Unexpected exception: " + t.getMessage());
+        } finally {
+            clearTestConfigDir();
+        }
+    }
+
+    @Test
+    public void testSharedPortSecureImplicitMismatch() {
+        try {
+            setTestConfigDir();
+            LdapConfig.loadLdapConfig("testConfig.shared-port-implicit-mismatch.properties");
+            Assert.fail("Expected ServiceConfigurationError for implicit secure mismatch on shared port");
+        } catch (ServiceConfigurationError expected) {
+            Assert.assertTrue(expected.getMessage().contains("Inconsistent secure setting for port 10636"));
+        } catch (Throwable t) {
+            log.error("Unexpected exception", t);
+            Assert.fail("Unexpected exception: " + t.getMessage());
+        } finally {
+            clearTestConfigDir();
         }
     }
 


### PR DESCRIPTION
This PR adds an optional per-pool secure setting to LDAP configuration so TLS can be enabled on non-standard ports (not just 636), while preserving existing behavior when the property is omitted. LdapConfig now validates that all pools sharing the same port agree on whether that port is secure, with new unit tests covering consistent, inconsistent, and order-independent cases. Configuration templates and READMEs are updated to document the new property and remove the unused dbrcHost key, and the module version is bumped to 1.3.40.